### PR TITLE
Fix marketplace.json schema for ralph-wiggum plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,11 @@
     },
     {
       "name": "ralph-wiggum",
-      "source": "anthropics/claude-code",
-      "directory": "plugins/ralph-wiggum",
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-code",
+        "path": "plugins/ralph-wiggum"
+      },
       "description": "Run Claude in a persistent loop until task completion"
     }
   ]


### PR DESCRIPTION
## What did you do?

Please include a summary of the changes.

- [ ] Added this
- [x] Updated that - Changed from invalid 'directory' field to proper 'path' field inside source object. Ralph-wiggum plugin now correctly references anthropics/claude-code repo with subdirectory path

## Why did you do it?

Why were these changes made?

- This was missing - getting `Error: Invalid schema`
- that needed changes

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
