### PR TITLE
Add onboard to help tour, flowchart for /bee:build

### DIFF
--- a/bee/commands/help.md
+++ b/bee/commands/help.md
@@ -29,12 +29,64 @@ Walk through commands one at a time, in this order (most common first):
 
 ### 1. `/bee:build` — The Main Workflow
 
-"**`/bee:build`** is the entry point for building anything. You tell it what you want to build, and it figures out the right workflow.
+"**`/bee:build`** is the main event — and it's opinionated. It codifies engineering discipline as a command. Instead of hoping developers spec before coding, write tests before shipping, or review before merging — Bee makes that the default path. You can always skip steps, but the guardrails are there.
 
-- **Typo or config fix?** It'll just fix it (delegates to a quick-fix agent).
+You tell it what you want to build, and it figures out the right workflow based on size and risk. Here's the flow:
+
+```
+ You describe what to build
+          │
+          ▼
+    ┌──────────┐
+    │  TRIAGE   │  Assess size (trivial → epic) + risk (low → high)
+    └────┬─────┘
+         │
+         ▼
+   ┌─────────────┐
+   │   CONTEXT    │  Read codebase — patterns, conventions, design system
+   └────┬────────┘
+        │
+        ▼
+   ┌─────────────┐
+   │  TIDY (opt) │  Clean up the area first? Separate commit.
+   └────┬────────┘
+        │
+        ├─────────────────────┐
+        ▼                     ▼
+  ┌───────────┐        ┌───────────┐
+  │  DESIGN   │        │ DISCOVERY │  (when UI involved)
+  │  (when    │        │ (when     │  and/or decision
+  │  needed)  │        │  needed)  │  density is high
+  └─────┬─────┘        └─────┬─────┘
+        │                     │
+        └──────────┬──────────┘
+                   ▼
+            ┌────────────┐
+            │    SPEC     │  Interview you, write testable acceptance criteria
+            └─────┬──────┘
+                  ▼
+          ┌───────────────┐
+          │ ARCHITECTURE  │  Evaluate options or confirm existing patterns
+          └───────┬───────┘
+                  ▼
+           ┌────────────┐
+           │  TDD PLAN   │  Step-by-step test-first implementation plan
+           └──────┬─────┘
+                  ▼
+         ┌─────────────────────────────────┐
+         │  For each slice:                │
+         │  EXECUTE → VERIFY → next slice  │
+         └────────────┬────────────────────┘
+                      ▼
+              ┌────────────┐
+              │   REVIEW    │  Full picture. Ship recommendation.
+              └────────────┘
+```
+
+- **Typo or config fix?** It skips most of this and just fixes it.
 - **Small bug or UI tweak?** Quick confirmation, then build.
-- **New feature?** Spec it, plan it, TDD it, verify it, review it.
-- **Epic (new subsystem)?** Break it into shippable phases, tackle each one.
+- **New feature?** The full flow above.
+- **Epic?** Breaks it into shippable phases, runs the full flow per phase.
 
 You can give it a task upfront:
 ```
@@ -51,7 +103,7 @@ Then ask:
 Use AskUserQuestion: "Want to hear about the next command?"
 Options: "Yes, next command" / "Tell me more about /bee:build" / "Skip to a specific command"
 
-If "Tell me more about /bee:build": explain the phases briefly — triage, context, tidy, design, discovery, spec, architecture, TDD plan, execute, verify, review. Mention the collaboration loop (`@bee` annotations, `[x] Reviewed`). Then re-offer "Next command?"
+If "Tell me more about /bee:build": explain the collaboration loop (`@bee` annotations in docs, `[x] Reviewed` gate), how risk flows downstream (HIGH = thorough spec + defensive tests + feature flag recommendation, LOW = lighter everything), and how Ralph can handle autonomous execution. Then re-offer "Next command?"
 
 If "Skip to a specific command": list all commands as options and let them pick.
 
@@ -95,7 +147,23 @@ This one is read-only — it analyzes but doesn't change code. Great for getting
 
 Then ask: "Next command?"
 
-### 4. `/bee:bee-coach` — Session Coaching
+### 4. `/bee:onboard` — Developer Onboarding
+
+"**`/bee:onboard`** is an interactive onboarding guide for new team members joining an existing project. It analyzes the codebase and delivers an adaptive walkthrough tailored to your role and focus area.
+
+It asks two questions upfront:
+- Your role and experience level (senior backend, frontend, mid-level, junior)
+- Which area of the codebase you'll be working on
+
+Then it walks you through the codebase section by section, with MCQ knowledge checks after each section to make sure things are clicking. Get an answer wrong and it explains the correct answer grounded in the actual code — not generic advice.
+
+After the walkthrough, you can keep asking questions in natural conversation.
+
+This one is read-only — no code changes. Great for onboarding onto a new project. Try it with `/bee:onboard`."
+
+Then ask: "Next command?"
+
+### 5. `/bee:bee-coach` — Session Coaching
 
 "**`/bee:bee-coach`** analyzes your Claude Code sessions and gives coaching insights. It looks at:
 - Workflow adoption (did you spec? plan? verify?)
@@ -112,7 +180,7 @@ Also read-only — no code changes, just insights. Needs a few sessions logged b
 
 Then ask: "Next command?"
 
-### 5. Skills (Reference Knowledge)
+### 6. Skills (Reference Knowledge)
 
 "Bee also ships with **skills** — shared reference knowledge that any agent can draw on. You can invoke them directly to learn Bee's principles:
 
@@ -128,7 +196,7 @@ Then ask: "Next command?"
 
 These are read-only references — no code changes. Pick any one to read up on a topic."
 
-### 6. Wrap-Up
+### 7. Wrap-Up
 
 After covering all commands (or if the developer says they've seen enough), close with:
 
@@ -136,6 +204,7 @@ After covering all commands (or if the developer says they've seen enough), clos
 - **`/bee:build`** for building anything (it picks the right process)
 - **`/bee:discover`** for exploring requirements before building
 - **`/bee:review`** for a health check on existing code
+- **`/bee:onboard`** for getting new team members up to speed
 - **`/bee:bee-coach`** for improving your workflow over time
 
 Most people start with `/bee:build [what you want to build]` and let Bee guide from there."
@@ -148,7 +217,7 @@ If there's active work: "Since there's active work on **[feature]**, running `/b
 
 If the developer asks to skip ahead, present:
 Use AskUserQuestion: "Which command do you want to know about?"
-Options: "/bee:build" / "/bee:discover" / "/bee:review" / "/bee:bee-coach" / "Skills (reference knowledge)"
+Options: "/bee:build" / "/bee:discover" / "/bee:review" / "/bee:onboard" / "/bee:bee-coach"
 
 Jump to that section, then offer to continue the tour from the next command.
 


### PR DESCRIPTION
## Summary
- Add `/bee:onboard` (developer onboarding) to the help guided tour
- Lead `/bee:build` section with opinionated framing — "codifies engineering discipline as a command"
- Add ASCII flowchart showing the full build workflow (triage → review)
- Update wrap-up summary and skip-to menu

## Test plan
- [ ] Run `/bee:help` and walk through `/bee:build` — verify flowchart renders correctly
- [ ] Verify `/bee:onboard` appears in the tour between review and coach
- [ ] Test "Skip to a specific command" — verify onboard is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)