### PR TITLE
Add /bee:migrate command

### DIFF
--- a/bee/commands/migrate.md
+++ b/bee/commands/migrate.md
@@ -1,0 +1,227 @@
+---
+description: Analyze a legacy and new codebase to produce a prioritized, independently-shippable migration plan.
+---
+
+You are Bee doing a migration analysis. The developer has a legacy codebase and a new codebase, and needs to move functionality from one to the other incrementally. Your job: analyze both codebases, interview the developer about their migration goals, and produce a prioritized migration plan where each unit is a clean PR that can be deployed to production.
+
+You are the **orchestrator**. You parse paths, spawn analysis agents, interview the developer, synthesize results, and write the migration plan. You are **read-only** — you never modify source code in either codebase. You produce a plan, not code.
+
+## Step 1: Parse Paths
+
+The developer's prompt (`$ARGUMENTS`) contains paths to two codebases and context about their migration goals. Extract:
+
+1. **Legacy codebase path** — the source system being migrated away from
+2. **New codebase path** — the target system where migrated functionality will land
+
+The developer writes naturally — paths may appear anywhere in the prompt. Look for absolute paths, relative paths, or directory names. If the prompt mentions only one path, ask which codebase it refers to and request the other.
+
+**Confirm your interpretation before proceeding.** Use Bash with `ls` to verify both paths exist as directories, then tell the developer:
+
+"I'm reading these as:
+- **Legacy:** `/path/to/legacy`
+- **New:** `/path/to/new`
+
+Correct?"
+
+Use AskUserQuestion with options: "Yes, that's right (Recommended)" / "Let me correct the paths"
+
+**If either path does not resolve to an existing directory**, report clearly and stop:
+"I can't find a directory at `[path]`. Please check the path and try again."
+
+**Monorepo case:** Both paths may be subdirectories of the same repository (e.g., `apps/legacy` and `apps/new`). This is fine — treat each subdirectory as an independent codebase for analysis purposes.
+
+## Step 2: Gather Context
+
+Once paths are confirmed, spawn **two context-gatherer agents in parallel** via the Task tool — one for each codebase. Spawn both in a single message so they run simultaneously.
+
+**Legacy context-gatherer** — use `subagent_type: bee:context-gatherer`, pass:
+- Project root: the legacy codebase path
+- Task description: "Scan this legacy codebase for a migration analysis. The developer's migration goal: [paste the developer's goal description from their prompt]. Focus on: project structure, architecture pattern, module boundaries, dependencies between modules, and any conventions or patterns that migrated code would need to account for."
+
+**New context-gatherer** — use `subagent_type: bee:context-gatherer`, pass:
+- Project root: the new codebase path
+- Task description: "Scan this new/target codebase for a migration analysis. The developer's migration goal: [paste the developer's goal description from their prompt]. Focus on: project structure, architecture pattern, folder conventions, existing patterns that incoming migrated code should follow, and integration points where new functionality would land."
+
+Store the results as **legacy context** and **new context** — both are used in every downstream step.
+
+## Step 3: Analyze Legacy Codebase
+
+After the **legacy** context-gatherer completes (you need its file list), spawn **two analysis agents in parallel** via the Task tool. The new context-gatherer can still be running — you don't need to wait for it.
+
+**review-coupling** — use `subagent_type: bee:review-coupling`, pass:
+- `files`: the list of source files identified by the legacy context-gatherer
+- `project_root`: the legacy codebase path
+
+This identifies natural extraction seams — modules with low afferent coupling that can be pulled out without touching half the system, and tightly coupled clusters that must migrate together.
+
+**review-behavioral** — use `subagent_type: bee:review-behavioral`, pass:
+- `files`: the list of source files identified by the legacy context-gatherer
+- `git_range`: "the beginning" (use full history — migration cares about lifetime activity, not just recent changes)
+- `project_root`: the legacy codebase path
+
+This identifies hotspots (high-churn + high-complexity files that are actively maintained) versus cold/dead code (files with no meaningful recent git activity that may be candidates to skip).
+
+**Graceful degradation:** If either agent fails, report which analysis was skipped and continue with the remaining results. A migration plan with only coupling data or only behavioral data is still useful — just less precise in its prioritization.
+
+## Step 4: Interview Developer
+
+Wait for all agents to complete before starting the interview. The analysis results make your questions specific and useful — without them, you'd be asking generic questions.
+
+Summarize what you found to the developer before asking questions:
+
+"Here's what I found:
+- **Legacy codebase:** [brief summary — tech stack, architecture, number of modules]
+- **New codebase:** [brief summary — tech stack, architecture, patterns]
+- **Coupling analysis:** [key findings — loosely coupled modules, tightly coupled clusters]
+- **Behavioral analysis:** [key findings — active hotspots, dead/cold code areas]"
+
+Then interview the developer. The goal is clarity — ask what you need to produce a high-quality plan. The number and depth of questions adapts to what the developer shares. Don't ask questions the analysis already answered.
+
+**Question areas** (use AskUserQuestion with concrete options drawn from the analysis):
+
+1. **Migration goals** — "What's driving this migration? What does success look like?"
+   Options should reflect what you see in the codebases (e.g., "Modernize the tech stack" / "Consolidate into a single system" / "Replace specific functionality")
+
+2. **Already migrated** — "Has any functionality already been moved to the new system?"
+   If the new codebase context shows existing modules that look like they came from the legacy system, reference them: "I see `[module]` in the new codebase — was this already migrated from the legacy system?"
+
+3. **Priorities** — "Which modules or capabilities should move first?"
+   Use the coupling analysis to offer concrete options: "The coupling analysis found these loosely-coupled modules that would be easiest to extract: [A, B, C]. Which area matters most to your users?"
+
+4. **Constraints** — "Anything that must NOT be migrated, or external dependencies I should know about?"
+   If the coupling analysis found tightly coupled clusters, mention them: "I see [X] and [Y] are tightly coupled — they'd need to move together. Any concerns with that?"
+
+**Dynamic depth:** If the developer gives detailed answers early, you may not need all four areas. If answers are brief or reveal complexity, ask follow-up questions. The interview ends when you have enough clarity to prioritize the migration units.
+
+## Step 5: Synthesize Migration Plan
+
+Combine all four data sources into a prioritized migration plan:
+
+1. **Coupling analysis** — which modules have natural seams (low afferent coupling, few external dependents) vs. which are tightly coupled clusters
+2. **Behavioral analysis** — which modules are actively maintained (hotspots) vs. cold/dead code
+3. **Context from both codebases** — tech stacks, architecture patterns, folder conventions, integration points
+4. **Developer interview answers** — goals, priorities, constraints, what's already migrated
+
+### Ordering Logic
+
+Prioritize migration units using this hierarchy:
+
+1. **Low coupling + high developer priority** — modules the developer wants first AND that are easy to extract. These are the low-hanging fruit.
+2. **Low coupling + actively maintained** — easy to extract and still actively used. Good early wins.
+3. **Moderate coupling + high developer priority** — the developer needs these, but they require more careful extraction.
+4. **Tightly coupled clusters** — these must move together. Place them later unless the developer's priorities override.
+5. **Low-activity modules** — still used but rarely changed. Lower urgency.
+
+### Dead Code → Skip Section
+
+Modules identified by the behavioral analysis as having **no meaningful recent git activity** (no commits in 12+ months, no active consumers) go in the **Skip** section, not as migration units. Include:
+- Module name
+- Last meaningful change date (from git history)
+- Reason to skip (dead code / no consumers / superseded by X)
+
+The developer confirms these before they're excluded.
+
+### Justification
+
+Each migration unit must explain **WHY** it is ordered where it is. Reference specific data:
+- "Low afferent coupling (only 2 dependents) — easy to extract independently"
+- "Hotspot: changed 47 times in the last year — actively maintained, high value"
+- "Developer priority: core business logic that must move first"
+- "Depends on Unit 2 (shared data model) — must follow"
+
+### Migration Unit Detail (Two Levels)
+
+Each unit has two levels of detail so it can feed directly into `/bee:build`:
+
+**Discovery-level summary:**
+- What module/capability is being moved
+- Why it is prioritized at this position
+- What it depends on in the legacy system (other modules, external services, data stores)
+
+**Spec-level detail:**
+- **Acceptance criteria** — testable behaviors that define "done" for this unit (checkboxes)
+- **Landing guidance** — how the migrated functionality should be structured in the new codebase, referencing specific patterns, folder conventions, and integration points from the new codebase's context-gatherer output. Migration isn't copy-paste — the code should adopt the new system's patterns.
+- **Risks** — known complications, external dependencies, data concerns, edge cases
+
+### Independence Constraint
+
+Each migration unit must be **independently shippable** — a single clean PR that can be deployed to production without depending on other units being completed first.
+
+When units have ordering dependencies (B requires A to be migrated first), state that dependency explicitly:
+- **Depends on:** Unit 2 (shared authentication module must exist in new system first)
+
+## Step 6: Output
+
+Before writing the plan, present a summary to the developer and confirm:
+
+"Here's the migration plan I've drafted:
+- **[N] migration units** ordered by priority
+- **[M] modules flagged as skip** (dead/cold code)
+- **[K] open questions** to resolve before starting
+
+Want me to save this to `docs/specs/migration-plan.md` in the new project?"
+
+Use AskUserQuestion with options: "Yes, save it (Recommended)" / "Let me review the details first" / "Make changes before saving"
+
+If "Let me review the details first" — show the full plan inline before saving.
+If "Make changes before saving" — ask what to change, adjust, then confirm again.
+
+### Output Template
+
+Save the migration plan to the new project's `docs/specs/migration-plan.md` using this structure:
+
+```markdown
+# Migration Plan: [Legacy Project Name] → [New Project Name]
+
+## Context
+
+### Legacy Codebase
+[Tech stack, architecture pattern, key modules, size — from legacy context-gatherer]
+
+### New Codebase
+[Tech stack, architecture pattern, folder conventions, existing patterns — from new context-gatherer]
+
+### Migration Goals
+[Developer's stated goals and priorities from the interview]
+
+## Migration Units
+
+### Unit 1: [Name]
+**Priority:** 1 | **Effort:** [S/M/L] | **Depends on:** none
+
+**Summary:** [What this module does, why it's first — references coupling/behavioral data]
+
+**Acceptance Criteria:**
+- [ ] [Testable behavior that defines "done"]
+- [ ] [Edge case or error handling]
+
+**Landing guidance:** [How this should be structured in the new codebase — specific folders, patterns, integration points from context-gatherer output]
+
+**Risks:** [Known complications, external dependencies, data concerns]
+
+---
+
+### Unit 2: [Name]
+**Priority:** 2 | **Effort:** [S/M/L] | **Depends on:** [none or Unit N]
+
+...
+
+## Skip (Candidates for Removal)
+
+| Module | Last meaningful change | Reason to skip |
+|--------|----------------------|----------------|
+| [name] | [date/timeframe]     | [dead code / no consumers / superseded by X] |
+
+## Open Questions
+
+[Anything the developer should resolve before starting execution — ambiguities, external dependencies to confirm, data migration concerns]
+```
+
+## Rules
+
+- **Read-only.** The migrate command doesn't change code in either codebase. It reads, analyzes, and produces a plan.
+- **Parallel first.** Spawn agents simultaneously where possible. Context-gatherers run in parallel. Coupling and behavioral analysis run in parallel after legacy context completes.
+- **Graceful degradation.** If any agent fails, skip that analysis and note it in the plan. Never fail the entire migration analysis because one agent had trouble.
+- **Confirm before saving.** Always get developer approval before writing the migration plan file.
+- **Migration, not translation.** The plan should recommend how code lands in the new system's patterns — not how to copy-paste legacy structure. Each landing guidance section references the new codebase's conventions.
+- **Every unit is shippable.** Each migration unit must be a clean PR that can deploy to production independently. If two modules must move together, they're one unit.

--- a/docs/specs/.bee-state.md
+++ b/docs/specs/.bee-state.md
@@ -1,0 +1,32 @@
+# Bee State
+
+## Feature
+/bee:migrate command — incremental migration planning from legacy to new codebase
+
+## Triage
+Size: FEATURE
+Risk: LOW
+
+## Discovery
+docs/specs/bee-migrate-discovery.md — reviewed
+
+## Current Phase
+single-phase (Phase 1 only — Phase 2 is future refinement)
+
+## Phase Spec
+docs/specs/bee-migrate-command.md — confirmed by developer
+
+## Architecture
+Simple → tdd-planner-simple
+
+## Current Slice
+Done — verified and reviewed
+
+## TDD Plan
+docs/specs/bee-migrate-tdd-plan.md — reviewed
+
+## Phase Progress
+Phase 1: done — shipped
+
+## Slice Progress
+Steps 1-10: all complete

--- a/docs/specs/bee-migrate-command.md
+++ b/docs/specs/bee-migrate-command.md
@@ -1,0 +1,124 @@
+# Spec: /bee:migrate Command
+
+## Overview
+
+A new command (`commands/migrate.md`) that helps developers incrementally migrate functionality from a legacy codebase to a new one. It composes existing agents (context-gatherer, review-coupling, review-behavioral) to analyze both codebases, interviews the developer about migration goals, and produces a prioritized migration plan where each unit is independently shippable and detailed enough to feed directly into `/bee:build`.
+
+## Acceptance Criteria
+
+### Path Parsing
+
+- [x] Command extracts legacy and new codebase paths from the developer's natural-language prompt
+- [x] Command confirms its interpretation of both paths before proceeding (e.g., "I'm reading legacy: /path/a, new: /path/b")
+- [x] Shows a clear error when either path cannot be resolved to an existing directory
+- [x] Handles the monorepo case where both paths are subdirectories of the same repository
+
+### Agent Orchestration
+
+- [x] Runs context-gatherer on both codebases (legacy and new) in parallel
+- [x] Runs review-coupling on the legacy codebase to identify natural extraction seams
+- [x] Runs review-behavioral on the legacy codebase to identify hotspots vs. dead/cold code
+- [x] review-coupling and review-behavioral run in parallel with each other (but after context-gatherer on legacy completes, since they need its output for scope)
+- [x] If any agent fails, the command reports which analysis was skipped and continues with remaining results
+
+### Agent Inputs
+
+- [x] context-gatherer receives the project root path and the developer's migration goal description
+- [x] review-coupling receives the legacy project root and the full list of source files from context-gatherer's scan
+- [x] review-behavioral receives the legacy project root, source files, and a git range (default: full history, since migration cares about lifetime activity not just recent)
+- [x] Each agent is spawned via Task tool, consistent with the review.md orchestration pattern
+
+### Developer Interview
+
+- [x] Interview happens after all agent analysis completes (so the command can reference findings in its questions)
+- [x] Asks about the developer's migration goals -- what outcome they want and what business drivers matter
+- [x] Asks what has already been migrated (so it is excluded from the plan)
+- [x] Asks about priorities -- what modules or capabilities should move first from a business perspective
+- [x] Asks about constraints -- anything that must NOT be migrated, dependencies on external systems, timeline pressure
+- [x] Interview is dynamic -- number and depth of questions adapts to what the developer shares (no fixed count)
+- [x] Interview uses AskUserQuestion with concrete options where possible, informed by the analysis results (e.g., "The coupling analysis found these loosely-coupled modules: [A, B, C]. Which area matters most to your users?")
+
+### Migration Plan Synthesis
+
+- [x] Combines coupling analysis (seams), behavioral analysis (activity vs. dead code), context from both codebases, and developer interview answers into a single prioritized plan
+- [x] Orders migration units: low-coupling + high-value modules first, tightly coupled clusters later
+- [x] Dead or near-dead code (identified by behavioral analysis as having no meaningful recent git activity) is listed in a separate "Skip" section rather than as migration units
+- [x] Each migration unit's priority is justified -- the plan explains WHY it is ordered where it is, referencing coupling data, activity data, or developer-stated priority
+
+### Migration Unit Detail (Two Levels)
+
+- [x] Each unit has a discovery-level summary: what module/capability is being moved, why it is prioritized here, and what it depends on in the legacy system
+- [x] Each unit has spec-level detail: acceptance criteria describing what "done" looks like, how the migrated functionality should land in the new codebase (referencing specific patterns, folder conventions, and integration points from the new codebase's context-gatherer output), and known risks or edge cases
+- [x] Each unit is scoped to be independently shippable -- a single clean PR that can be deployed to production without depending on other units being completed first
+- [x] Units that have ordering dependencies (B requires A to be migrated first) state that dependency explicitly
+
+### Output
+
+- [x] Migration plan is saved to the new project's `docs/specs/migration-plan.md`
+- [x] Plan follows a consistent markdown structure (see API Shape below)
+- [x] Command confirms the plan with the developer before saving
+
+### Command File Format
+
+- [x] `commands/migrate.md` has frontmatter with `description` field, matching existing command conventions
+- [x] Command file is read-only -- it analyzes and produces a plan, never modifies source code in either codebase
+
+## API Shape
+
+The migration plan output structure:
+
+```
+# Migration Plan: [Legacy Project] -> [New Project]
+
+## Context
+[Summary of both codebases -- tech stacks, patterns, key differences]
+[Developer's stated goals and priorities]
+
+## Migration Units
+
+### Unit 1: [Name]
+**Priority:** [1-N] | **Effort:** [S/M/L] | **Depends on:** [none or Unit N]
+
+**Summary:** [What this module does, why it's first -- references coupling/behavioral data]
+
+**Acceptance Criteria:**
+- [ ] [Testable behavior that defines "done" for this unit]
+- [ ] [Error/edge case]
+- [ ] ...
+
+**Landing guidance:** [How this should be structured in the new codebase -- specific folders, patterns, integration points from context-gatherer output]
+
+**Risks:** [Known complications, external dependencies, data concerns]
+
+### Unit 2: [Name]
+...
+
+## Skip (Candidates for Removal)
+| Module | Last meaningful change | Reason to skip |
+|--------|----------------------|----------------|
+| [name] | [date/timeframe]     | [dead code / no consumers / superseded by X] |
+
+## Open Questions
+[Anything the developer should resolve before starting execution]
+```
+
+## Out of Scope
+
+- Automated code translation or code generation -- this command produces a plan, not code
+- Executing the migration -- each unit is a future task for `/bee:build`
+- Database migration planning -- schema changes, data migration scripts, data integrity
+- Runtime behavior analysis -- static analysis and git history only, no production metrics
+- Multi-repo git operations -- the command reads two paths but does not manage branches, merges, or deployments
+- New agent creation -- all analysis is done by composing existing agents
+- Effort estimation with time units -- effort is sized as S/M/L, not hours or days
+
+## Technical Context
+
+- **Patterns to follow:** `commands/review.md` for agent orchestration via Task tool (parallel spawning, graceful degradation on failure, result merging). `commands/build.md` for interview flow with AskUserQuestion and state awareness.
+- **Key dependencies:** Three existing agents -- `agents/context-gatherer.md`, `agents/review-coupling.md`, `agents/review-behavioral.md`. No new agents needed.
+- **Deliverable:** Single file `bee/commands/migrate.md` with frontmatter matching existing command conventions.
+- **Risk level:** LOW -- this is a new command composing existing, tested agents. No changes to existing code.
+
+---
+
+<p align="center">[x ] Reviewed</p>

--- a/docs/specs/bee-migrate-discovery.md
+++ b/docs/specs/bee-migrate-discovery.md
@@ -1,0 +1,81 @@
+# Discovery: /bee:migrate Command
+
+## Why
+
+Developers migrating from a legacy codebase to a new one face a hard question: where do I start, and in what order? Today they eyeball the old system, guess at boundaries, and hope they pick the right module to move first. Migration isn't just code translation -- it's an opportunity to improve boundaries and align with the new system's patterns. Bee already has agents that understand codebases (context-gatherer), find structural seams (review-coupling), and identify what's actively maintained versus dead code (review-behavioral). This command composes those agents into a migration-specific workflow that replaces guesswork with data-driven prioritization.
+
+## Who
+
+**Developers leading a migration** -- they have a legacy system and a new system, and need to move functionality from one to the other incrementally. They want each migration step to be a clean, deployable PR that doesn't break anything and can serve production traffic.
+
+## Success Criteria
+
+- Developer can point the command at two codebases (legacy and new) and get a prioritized migration plan without manual analysis
+- Each unit in the migration plan is independently shippable -- a clean PR that's also deployable to production
+- Low-hanging fruit surfaces first, informed by coupling analysis (natural seams) and behavioral analysis (what's actively maintained vs. dead)
+- The migration plan accounts for the new system's patterns, so migrated code lands in the right shape -- not a copy-paste of legacy structure
+- The plan is saved in the new project's `docs/specs/migration-plan.md`, consistent with other Bee output
+
+## Problem Statement
+
+When migrating a legacy system to a new one, developers lack a structured way to identify what to move, in what order, and where the natural extraction points are. They end up either trying to move too much at once (big bang) or picking migration units arbitrarily. The result is wasted effort on code that turns out to be dead, tangled dependencies that force rework, and migrated code that carries over legacy patterns instead of adopting the new system's conventions. This command gives developers a data-informed migration roadmap where every unit is sized for safe, incremental delivery.
+
+## Hypotheses
+
+- H1: Running review-coupling on the legacy codebase will reliably surface natural seams -- modules with low afferent coupling that can be extracted without touching half the system.
+- H2: Running review-behavioral on the legacy codebase will identify dead or near-dead code that can be skipped entirely, reducing migration scope significantly.
+- H3: Running context-gatherer on the new codebase provides enough pattern information for the migration plan to recommend how migrated code should be structured (not just what to move, but how it should land).
+- H4: A short developer interview (migration goals, what's already been moved, priorities) is sufficient to turn the analysis into a prioritized plan -- the command doesn't need deep domain knowledge beyond what the developer provides.
+
+## Out of Scope
+
+- Automated code translation or code generation -- this command produces a plan, not code
+- Executing the migration -- each unit in the plan is a future task (could be handed to `/bee:build`)
+- Database migration planning -- schema changes, data migration scripts, and data integrity concerns are a separate problem
+- Runtime behavior analysis -- this uses static analysis and git history only, not production metrics or traffic patterns
+- Multi-repo orchestration -- the command analyzes two paths the developer provides, but doesn't manage git operations across repos
+
+## Milestone Map
+
+### Phase 1: The core command -- analyze both codebases and produce a migration plan
+
+- Developer invokes `/bee:migrate` with a prompt containing paths to the legacy and new codebases, plus any context about goals and priorities
+- Command runs context-gatherer on both codebases to understand each independently (structure, patterns, conventions)
+- Command runs review-coupling on the legacy codebase to find natural extraction seams and identify tightly coupled clusters
+- Command runs review-behavioral on the legacy codebase to surface hotspots (actively maintained code) versus cold/dead code
+- Command interviews the developer about migration goals, what's already been moved, and what matters most
+- Command synthesizes all analysis into a prioritized migration plan saved to the new project's `docs/specs/migration-plan.md`
+- Each migration unit in the plan includes: what to move, why it's prioritized where it is, what it depends on, and how it should land in the new system's patterns
+- Migration units are ordered: low-coupling/high-value modules first, tightly coupled clusters later, dead code flagged as "skip"
+
+### Phase 2: Refinements based on real-world usage
+
+- Support for partial re-runs (developer has moved some units, wants to re-analyze what remains)
+- Integration with `/bee:build` so a developer can pick a migration unit and immediately start a build workflow for it
+- Richer "how it should land" recommendations using the new codebase's architecture patterns more deeply
+
+## Open Questions
+
+- How should the command handle monorepos where legacy and new code live in the same repository but different directories? The two-path model works, but the developer experience might need a hint.
+- Should the migration plan include effort estimates per unit? The coupling and behavioral data could inform rough sizing, but it might create false precision.
+- When the legacy codebase has no meaningful git history (e.g., vendor code, acqui-hire), the behavioral analysis degrades gracefully -- but should the command explicitly warn and adjust its prioritization strategy?
+
+## Key Decisions Resolved
+
+| Decision | Resolution | Rationale |
+|----------|-----------|-----------|
+| Where the migration plan is saved | New project's `docs/specs/migration-plan.md` | That's where work happens going forward |
+| What "independently shippable" means | Each unit is both a clean PR and deployable to production | Each migration step must serve traffic safely -- no "move now, fix later" |
+| New agents vs. composing existing ones | Compose existing agents (context-gatherer, review-coupling, review-behavioral) plus a migration-specific synthesis step | Reuse what works; the novel part is the synthesis, not the analysis |
+| Command vs. agent boundary | `commands/migrate.md` orchestrates; no new agents needed for Phase 1 | The orchestrator runs existing agents on the right targets and synthesizes results -- same pattern as `/bee:review` |
+
+## Revised Assessment
+
+Size: FEATURE -- this is a single command file (`commands/migrate.md`) that orchestrates existing agents in a new combination. The analysis agents already exist; the new work is the orchestration logic, the developer interview flow, and the migration plan output format. One phase of real work, with Phase 2 as future refinement.
+
+Greenfield: no -- this extends the existing Bee plugin with a new command, following established patterns.
+
+
+
+[x] Reviewed
+

--- a/docs/specs/bee-migrate-tdd-plan.md
+++ b/docs/specs/bee-migrate-tdd-plan.md
@@ -1,0 +1,192 @@
+# TDD Plan: /bee:migrate Command
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/bee-migrate-command.md`
+- **Deliverable**: Single file `bee/commands/migrate.md`
+- **Risk**: LOW
+- **Architecture**: Simple -- markdown command file with YAML frontmatter + prompt body
+- **Pattern reference**: `bee/commands/review.md` (parallel agent spawning, graceful degradation), `bee/commands/build.md` (interview flow with AskUserQuestion)
+- **Agents used**: `agents/context-gatherer.md`, `agents/review-coupling.md`, `agents/review-behavioral.md`
+
+## Codebase Conventions
+
+### Command File Structure
+- YAML frontmatter with `description` field
+- Prompt body in markdown sections
+- Agents spawned via Task tool
+- AskUserQuestion for developer interaction
+- Existing commands: `review.md` (182 lines), `build.md` (525 lines), `discover.md`, `bee-coach.md`
+
+### Verification Method
+No test framework exists. Each step is verified by reading the file and confirming it matches the acceptance criteria. "Test" = manual inspection that the section exists, is coherent, and follows conventions.
+
+---
+
+## Step 1: Frontmatter and Role Declaration
+
+**AC**: Command file has frontmatter with `description` field matching existing conventions. Command declares itself as read-only and states its purpose.
+
+- [x] **CREATE** the file `bee/commands/migrate.md`
+  - YAML frontmatter with `description` field (one-liner, similar style to review.md and discover.md)
+  - Opening paragraph: role declaration -- "You are Bee doing a migration analysis..."
+  - State read-only rule: this command produces a plan, never modifies source code
+
+- [x] **VERIFY**: Frontmatter `description` field exists and is a single sentence. Opening paragraph establishes role and read-only constraint. Compare style against `review.md` line 1-6.
+
+---
+
+## Step 2: Path Parsing Section
+
+**AC**: Command extracts legacy and new codebase paths from the developer's prompt, confirms interpretation, handles errors and monorepo case.
+
+- [x] **ADD** a "Step 1: Parse Paths" section to the command
+  - Instruct the LLM to extract two paths from `$ARGUMENTS` (natural language)
+  - Confirm interpretation with the developer before proceeding: "I'm reading legacy: /path/a, new: /path/b"
+  - Error handling: if either path cannot be resolved, report clearly and stop
+  - Monorepo note: both paths may be subdirectories of the same repo -- handle gracefully
+
+- [x] **VERIFY**: Section covers all four path-parsing ACs. Confirmation step uses a clear quoted format. Error case is explicit (stop, do not proceed). Monorepo case is mentioned.
+
+---
+
+## Step 3: Agent Orchestration -- Context Gathering (Parallel)
+
+**AC**: Runs context-gatherer on both codebases in parallel. Each agent receives project root path and migration goal description. Spawned via Task tool.
+
+- [x] **ADD** a "Step 2: Gather Context" section
+  - Spawn two context-gatherer agents in parallel via Task tool (one per codebase)
+  - Each receives: project root path + developer's migration goal description
+  - Pattern: match `review.md` Step 2 style (spawn in a single message for parallelism)
+  - Store results as "legacy context" and "new context" for downstream use
+
+- [x] **VERIFY**: Two parallel Task spawns described. Inputs match the Agent Inputs AC. Style matches review.md parallel spawning pattern.
+
+---
+
+## Step 4: Agent Orchestration -- Coupling and Behavioral Analysis (Parallel, After Legacy Context)
+
+**AC**: review-coupling and review-behavioral run in parallel with each other, but after context-gatherer on legacy completes. Each receives correct inputs. Graceful degradation on failure.
+
+- [x] **ADD** a "Step 3: Analyze Legacy Codebase" section
+  - Wait for legacy context-gatherer to complete (need its file list)
+  - Spawn review-coupling and review-behavioral in parallel via Task tool
+  - review-coupling receives: legacy project root + source file list from context-gatherer
+  - review-behavioral receives: legacy project root + source files + git range (default: full history)
+  - Graceful degradation: if any agent fails, report which analysis was skipped and continue
+
+- [x] **VERIFY**: Dependency ordering is correct (after context-gatherer, not before). Both agents spawn in parallel. Inputs match the Agent Inputs ACs. Git range default is "full history." Failure handling matches review.md graceful degradation pattern.
+
+---
+
+## Step 5: Developer Interview Flow
+
+**AC**: Interview happens after all analysis completes. Dynamic questions informed by analysis results. Uses AskUserQuestion with concrete options.
+
+- [x] **ADD** a "Step 4: Interview Developer" section covering these question areas:
+  - Migration goals -- what outcome, what business drivers
+  - Already migrated -- what to exclude from the plan
+  - Priorities -- which modules or capabilities should move first
+  - Constraints -- what must NOT be migrated, external dependencies, timeline pressure
+  - Dynamic behavior: number and depth of questions adapts to what the developer shares
+  - AskUserQuestion with concrete options drawn from analysis results (e.g., "The coupling analysis found these loosely-coupled modules: [A, B, C]. Which area matters most?")
+
+- [x] **VERIFY**: All four question areas are covered. Questions reference analysis results (not generic). AskUserQuestion is used with options. Dynamic interview is described (no fixed question count). Style matches build.md interview pattern.
+
+---
+
+## Step 6: Migration Plan Synthesis Logic
+
+**AC**: Combines all inputs into a prioritized plan. Orders by low-coupling + high-value first. Dead code goes to Skip section. Each unit's priority is justified.
+
+- [x] **ADD** a "Step 5: Synthesize Migration Plan" section
+  - Combine: coupling analysis (seams), behavioral analysis (activity vs dead code), context from both codebases, interview answers
+  - Ordering rule: low-coupling + high-value modules first, tightly-coupled clusters later
+  - Dead code handling: modules with no meaningful recent git activity go to "Skip" section, not migration units
+  - Justification requirement: each unit explains WHY it is ordered where it is, referencing coupling data, activity data, or developer-stated priority
+
+- [x] **VERIFY**: Synthesis combines all four data sources. Ordering logic is explicit. Dead code rule is clear. Justification requirement is stated.
+
+---
+
+## Step 7: Migration Unit Detail Template
+
+**AC**: Each unit has discovery-level summary and spec-level detail. Each unit is independently shippable. Ordering dependencies are stated explicitly.
+
+- [x] **ADD** unit detail requirements within Step 5
+  - Discovery-level summary: what module is being moved, why it is prioritized here, what it depends on in the legacy system
+  - Spec-level detail: acceptance criteria for "done", how the migrated functionality lands in the new codebase (referencing patterns/folders/integration points from new codebase context-gatherer), known risks
+  - Independently shippable: each unit is a single clean PR that can deploy without depending on other units
+  - Ordering dependencies: if B requires A first, state it explicitly
+
+- [x] **VERIFY**: Both detail levels are described. New codebase patterns are referenced (not just legacy). Independence constraint is clear. Dependency notation is specified.
+
+---
+
+## Step 8: Output Format and Confirmation
+
+**AC**: Plan saved to `docs/specs/migration-plan.md` in the new project. Follows the markdown structure from the spec's API Shape. Command confirms with developer before saving.
+
+- [x] **ADD** a "Step 6: Output" section
+  - Include the output template matching the API Shape from the spec (Context, Migration Units with Priority/Effort/Depends-on/Summary/AC/Landing-guidance/Risks, Skip table, Open Questions)
+  - Confirm the plan with the developer via AskUserQuestion before writing to disk
+  - Save location: new project's `docs/specs/migration-plan.md`
+
+- [x] **VERIFY**: Output template matches the API Shape section from the spec. Confirmation step exists before save. Save path is correct.
+
+---
+
+## Step 9: Graceful Degradation and Edge Cases
+
+**AC**: Agent failures are reported and skipped. Command is read-only.
+
+- [x] **ADD** a "Rules" section at the end of the command file
+  - Read-only: never modify source code in either codebase
+  - Graceful degradation: if any agent fails, report which analysis was skipped and continue with remaining results
+  - Parallel first: spawn agents simultaneously where possible
+  - Confirm before saving: always get developer approval before writing the plan file
+
+- [x] **VERIFY**: Rules section covers read-only, graceful degradation, parallel-first, and confirm-before-save. Matches review.md Rules section style.
+
+---
+
+## Step 10: Full File Review
+
+- [x] **READ** the complete `bee/commands/migrate.md` and verify end-to-end flow:
+  - Frontmatter has `description` field
+  - Path parsing extracts two paths and confirms
+  - Context-gatherer runs on both codebases in parallel
+  - review-coupling and review-behavioral run in parallel after legacy context completes
+  - All agent inputs match the spec's Agent Inputs section
+  - Interview happens after analysis, is dynamic, uses AskUserQuestion with analysis-informed options
+  - Synthesis combines all four data sources with correct ordering logic
+  - Each migration unit has both detail levels and is independently shippable
+  - Output follows the API Shape template
+  - Plan is confirmed before saving
+  - Rules enforce read-only, graceful degradation, and parallel execution
+
+- [x] **VERIFY**: All acceptance criteria from the spec are covered. (Spec has 33 ACs across 8 groups; all verified present in migrate.md.) No spec AC is missing. No section contradicts another.
+
+---
+
+## Summary
+| Category | # Steps | Status |
+|----------|---------|--------|
+| Frontmatter + role | 1 | |
+| Path parsing | 1 | |
+| Context gathering | 1 | |
+| Legacy analysis | 1 | |
+| Developer interview | 1 | |
+| Plan synthesis | 1 | |
+| Unit detail | 1 | |
+| Output format | 1 | |
+| Edge cases / rules | 1 | |
+| Full file review | 1 | |
+| **Total** | **10** | |
+
+<p align="center">[x] Reviewed</p>


### PR DESCRIPTION
## Summary
- Adds `/bee:migrate` command that composes context-gatherer, review-coupling, and review-behavioral agents across two codebases to produce a prioritized migration plan
- Each migration unit is independently shippable (clean PR + deployable to production)
- Includes discovery doc, spec, and TDD plan in `docs/specs/`

## Test plan
- [ ] Invoke `/bee:migrate` with two valid codebase paths and verify it parses them correctly
- [ ] Verify context-gatherer runs on both codebases in parallel
- [ ] Verify coupling + behavioral analysis runs on legacy codebase after context completes
- [ ] Verify interview flow asks dynamic questions informed by analysis results
- [ ] Verify migration plan output matches the documented API Shape template
- [ ] Verify dead code appears in Skip section, not as migration units

🤖 Generated with [Claude Code](https://claude.com/claude-code)