### PR TITLE
Add /bee:migrate and /bee:coach to help tour and README

### DIFF
--- a/bee/README.md
+++ b/bee/README.md
@@ -60,6 +60,18 @@ Standalone code review with hotspot analysis, tech debt prioritization, and deve
 
 Interactive developer onboarding for existing projects. Analyzes the codebase and delivers an adaptive walkthrough — architecture, entry points, domain concepts, tribal knowledge, dragons, and how to run/test/deploy. Adapts to the developer's role, experience level, and focus area. Includes MCQ knowledge checks.
 
+```
+/bee:migrate /path/to/legacy /path/to/new-app
+```
+
+Analyze a legacy and new codebase to produce a prioritized, independently-shippable migration plan. Reads both codebases, interviews you about goals, and writes a plan where each unit is a clean PR. Read-only — produces a plan, not code.
+
+```
+/bee:coach
+```
+
+Analyze your Claude Code sessions and get actionable coaching insights — workflow adoption, prompt quality, session efficiency, and code quality signals. Tracks trends over time.
+
 ## How It Works
 
 Bee assesses every task on two axes — **size** and **risk** — then recommends the right workflow.
@@ -193,7 +205,10 @@ bee/
 │   └── plugin.json               # Plugin manifest
 ├── commands/
 │   ├── build.md                   # /bee:build orchestrator
+│   ├── coach.md                   # /bee:coach session coaching insights
 │   ├── discover.md               # /bee:discover standalone discovery
+│   ├── help.md                    # /bee:help interactive guided tour
+│   ├── migrate.md                 # /bee:migrate migration planning
 │   ├── onboard.md                # /bee:onboard interactive developer onboarding
 │   └── review.md                 # /bee:review standalone code review
 ├── agents/

--- a/bee/commands/help.md
+++ b/bee/commands/help.md
@@ -163,7 +163,22 @@ This one is read-only — no code changes. Great for onboarding onto a new proje
 
 Then ask: "Next command?"
 
-### 5. `/bee:coach` — Session Coaching
+### 5. `/bee:migrate` — Migration Planning
+
+"**`/bee:migrate`** analyzes a legacy codebase and a new codebase, then produces a prioritized migration plan where each unit is a clean PR that can be deployed to production.
+
+You give it two paths — the legacy system and the target system:
+```
+/bee:migrate /path/to/legacy /path/to/new-app
+```
+
+It reads both codebases, interviews you about migration goals and priorities, then writes a plan with independently-shippable migration units.
+
+This one is read-only — it produces a plan, not code. No files in either codebase are modified. Great for scoping a migration before you start cutting code."
+
+Then ask: "Next command?"
+
+### 6. `/bee:coach` — Session Coaching
 
 "**`/bee:coach`** analyzes your Claude Code sessions and gives coaching insights. It looks at:
 - Workflow adoption (did you spec? plan? verify?)
@@ -180,7 +195,7 @@ Also read-only — no code changes, just insights. Needs a few sessions logged b
 
 Then ask: "Next command?"
 
-### 6. Skills (Reference Knowledge)
+### 7. Skills (Reference Knowledge)
 
 "Bee also ships with **skills** — shared reference knowledge that any agent can draw on. You can invoke them directly to learn Bee's principles:
 
@@ -196,7 +211,7 @@ Then ask: "Next command?"
 
 These are read-only references — no code changes. Pick any one to read up on a topic."
 
-### 7. Wrap-Up
+### 8. Wrap-Up
 
 After covering all commands (or if the developer says they've seen enough), close with:
 
@@ -205,6 +220,7 @@ After covering all commands (or if the developer says they've seen enough), clos
 - **`/bee:discover`** for exploring requirements before building
 - **`/bee:review`** for a health check on existing code
 - **`/bee:onboard`** for getting new team members up to speed
+- **`/bee:migrate`** for planning incremental migrations between codebases
 - **`/bee:coach`** for improving your workflow over time
 
 Most people start with `/bee:build [what you want to build]` and let Bee guide from there."
@@ -217,7 +233,7 @@ If there's active work: "Since there's active work on **[feature]**, running `/b
 
 If the developer asks to skip ahead, present:
 Use AskUserQuestion: "Which command do you want to know about?"
-Options: "/bee:build" / "/bee:discover" / "/bee:review" / "/bee:onboard" / "/bee:coach"
+Options: "/bee:build" / "/bee:discover" / "/bee:review" / "/bee:onboard" / "/bee:migrate"
 
 Jump to that section, then offer to continue the tour from the next command.
 


### PR DESCRIPTION
## Summary
- Add `/bee:migrate` section to help guided tour (migration planning between codebases)
- Add `/bee:migrate` and `/bee:coach` to README standalone commands section
- Add `coach.md`, `help.md`, `migrate.md` to README project structure tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)