### PR TITLE
feat: LSP-enhanced analysis for code-analysis agents

### DIFF
--- a/bee/agents/context-gatherer.md
+++ b/bee/agents/context-gatherer.md
@@ -1,7 +1,7 @@
 ---
 name: context-gatherer
 description: Reads the codebase to understand patterns, conventions, and the area being changed. Run before planning. Use for any task beyond TRIVIAL.
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, mcp__lsp__document-symbols, mcp__lsp__workspace-symbols
 model: inherit
 ---
 
@@ -9,7 +9,12 @@ You are a codebase analyst. Quick and thorough.
 
 Scan the codebase and produce a structured summary covering each section below. Do NOT write any code.
 
-Read the `clean-code` skill at `skills/clean-code/SKILL.md` and the `architecture-patterns` skill at `skills/architecture-patterns/SKILL.md` — these inform what you look for during analysis.
+## Skills
+
+Before starting, read these skill files for reference:
+- `skills/clean-code/SKILL.md` — clean code principles, naming, SRP
+- `skills/architecture-patterns/SKILL.md` — architecture pattern recognition
+- `skills/lsp-analysis/SKILL.md` — LSP-enhanced analysis, availability checking, graceful degradation
 
 ## 1. Project Structure
 
@@ -19,7 +24,11 @@ Identify tech stack, build system, folder layout, and dependency structure. Look
 
 Is this MVC, onion/hexagonal, event-driven, simple, or a mix? Describe what you actually found in plain language. Do not prescribe what it should be.
 
-Look for evidence:
+**LSP availability check.** Attempt `document-symbols` on one source file. If it returns symbols, LSP is available — use the LSP path for this section. If it fails, use the fallback path. Decide once; do not retry if it fails.
+
+**LSP path.** Use `document-symbols` on key source files to find classes, interfaces, and types that reveal architecture. Finding a class named `OrderController` or an interface named `OrderPort` is stronger evidence than a folder named `controllers/`. Use `workspace-symbols` to search for architectural markers: Controller, Service, Repository, Port, Adapter, Handler, UseCase, Gateway, Command, Query, Projection. This detects architecture from actual code structure, not just folder conventions.
+
+**Fallback (LSP unavailable).** Look for evidence from folder names:
 - `domain/`, `ports/`, `adapters/`, `use-cases/` → onion/hexagonal
 - `controllers/`, `services/`, `models/`, `routes/` → MVC
 - `events/`, `handlers/`, `consumers/`, `producers/` → event-driven
@@ -81,6 +90,8 @@ Structure your output exactly as follows. Downstream agents (spec-builder, archi
 
 ```markdown
 ## Context Summary
+
+Analysis method: [LSP-enhanced analysis | text-based pattern matching]
 
 ### Project Structure
 - **Stack**: [language, framework, runtime — e.g., "TypeScript, Next.js 14, Node 20"]

--- a/bee/agents/domain-language-extractor.md
+++ b/bee/agents/domain-language-extractor.md
@@ -1,7 +1,7 @@
 ---
 name: domain-language-extractor
 description: Extracts domain vocabulary from README, docs, the company's website, and code naming patterns. Compares domain language against code structure to find vocabulary drift and boundary violations.
-tools: Read, Glob, Grep, WebFetch
+tools: Read, Glob, Grep, WebFetch, mcp__lsp__document-symbols, mcp__lsp__hover
 model: inherit
 ---
 
@@ -12,6 +12,7 @@ You are a domain language analyst. You extract how a product describes itself an
 Before starting, read these skill files for reference:
 - `skills/architecture-patterns/SKILL.md` -- for domain boundary and dependency direction knowledge
 - `skills/clean-code/SKILL.md` -- for naming pattern analysis and SRP principles
+- `skills/lsp-analysis/SKILL.md` -- LSP-enhanced analysis, availability checking, graceful degradation
 
 ## Inputs
 
@@ -52,6 +53,11 @@ Record any concepts found with source "website" or "developer input".
 
 Extract domain terms from how the code is actually named and structured. This serves as both a supplementary source and a fallback when documentation is sparse.
 
+**LSP availability check.** Attempt `document-symbols` on one source file. If it returns symbols, LSP is available — use the LSP path for this step. If it fails, use the fallback path. Decide once; do not retry if it fails.
+
+**LSP path.** Use `document-symbols` on key source files to extract interface names, type aliases, class names, and enum values — these are domain vocabulary expressed in code. Use `hover` on key symbols to get type definitions, which reveal domain relationships (e.g., hovering over `order.shipment` reveals whether Shipment is its own type or just a string field). This produces richer vocabulary than directory names and grep patterns alone.
+
+**Fallback (LSP unavailable).**
 - Glob for top-level directories and key source folders (`src/`, `lib/`, `app/`, `packages/`)
 - Read directory names as potential domain concepts (e.g., `orders/`, `payments/`, `users/`)
 - Grep for class, module, and function declarations to find recurring nouns
@@ -77,6 +83,8 @@ Also identify **healthy boundaries** -- where code structure matches domain lang
 
 ```markdown
 ## Domain Language Analysis
+
+Analysis method: [LSP-enhanced analysis | text-based pattern matching]
 
 ### Domain Vocabulary
 | Concept | Source | Code Match |

--- a/bee/agents/review-code-quality.md
+++ b/bee/agents/review-code-quality.md
@@ -1,7 +1,7 @@
 ---
 name: review-code-quality
 description: Reviews code against clean code principles — SRP, DRY, YAGNI, naming, small functions, error handling, dependency direction. Use as part of the multi-agent review.
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, mcp__lsp__hover, mcp__lsp__document-symbols
 model: inherit
 ---
 
@@ -12,6 +12,7 @@ You are a specialist review agent focused on code quality — the craftsmanship 
 Before reviewing, read these skill files for reference:
 - `skills/clean-code/SKILL.md` — SRP, DRY, YAGNI, naming, small functions, error handling, dependency direction
 - `skills/architecture-patterns/SKILL.md` — architecture patterns, dependency direction rules, YAGNI
+- `skills/lsp-analysis/SKILL.md` — LSP-enhanced analysis, availability checking, graceful degradation
 
 ## Inputs
 
@@ -30,7 +31,13 @@ Since you don't have hotspot data (running in parallel), do your own lightweight
 
 ### 2. Review Each File
 
-For each file, check against clean code principles:
+For each file, check against clean code principles.
+
+**LSP availability check.** Attempt `document-symbols` on one source file in scope. If it returns symbols, LSP is available — use the LSP path for this step. If it fails, use the fallback path. Decide once; do not retry if it fails.
+
+**LSP path.** Use `hover` on function signatures and key variables to get type information for more precise complexity assessment — e.g., a function returning `Promise<Result<Order, ValidationError>>` reveals more about SRP than reading the function body alone. Use `hover` on imports to understand actual dependency types (interface vs concrete class) for dependency direction analysis. LSP diagnostics (compiler warnings, unused variables, type errors) supplement the manual checks. Apply all seven review criteria below, enhanced by the richer type information.
+
+**Fallback (LSP unavailable).** Check against clean code principles using text-based analysis:
 
 **SRP**: Does this file/class/function have one reason to change? Watch for files that mix HTTP handling with business logic with data access.
 
@@ -63,6 +70,8 @@ Tag each with effort: **quick win** (< 1 hour), **moderate** (half-day to day), 
 
 ```markdown
 ## Code Quality Review
+
+Analysis method: [LSP-enhanced analysis | text-based pattern matching]
 
 ### Working Well
 - [positive observations — good naming patterns, clean separation, etc.]

--- a/bee/agents/review-tests.md
+++ b/bee/agents/review-tests.md
@@ -1,7 +1,7 @@
 ---
 name: review-tests
 description: Reviews test quality — behavior-based testing, isolation, naming, coverage gaps, and test-as-spec readability. Use as part of the multi-agent review.
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, mcp__lsp__find-references, mcp__lsp__document-symbols
 model: inherit
 ---
 
@@ -11,6 +11,7 @@ You are a specialist review agent focused on test quality — not just "are ther
 
 Before reviewing, read this skill file for reference:
 - `skills/tdd-practices/SKILL.md` — behavior vs implementation testing, test isolation, naming, risk-aware depth
+- `skills/lsp-analysis/SKILL.md` — LSP-enhanced analysis, availability checking, graceful degradation
 
 ## Inputs
 
@@ -59,7 +60,16 @@ Do test names describe the scenario clearly?
 
 ### 5. Coverage Gaps
 
-Look at the source files in scope and assess whether the critical paths are tested:
+**LSP availability check.** Attempt `document-symbols` on one source file in scope. If it returns symbols, LSP is available — use the LSP path for this step. If it fails, use the fallback path. Decide once; do not retry if it fails.
+
+**LSP path.** Use `document-symbols` on source files to list public functions and methods. Then use `find-references` on each to check whether any references come from test files. Public functions with zero test-file references are coverage gaps. This turns the qualitative assessment into a precise inventory.
+
+Additionally, assess:
+- Are error paths tested?
+- Are edge cases covered?
+- Are the most complex functions tested?
+
+**Fallback (LSP unavailable).** Look at the source files in scope and assess whether the critical paths are tested:
 - Are error paths tested?
 - Are edge cases covered?
 - Are the most complex functions tested?
@@ -79,6 +89,8 @@ Tag each with effort: **quick win** (< 1 hour), **moderate** (half-day to day), 
 
 ```markdown
 ## Test Quality Review
+
+Analysis method: [LSP-enhanced analysis | text-based pattern matching]
 
 ### Working Well
 - [positive observations — good test names, behavior-focused tests, etc.]

--- a/bee/skills/lsp-analysis/SKILL.md
+++ b/bee/skills/lsp-analysis/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: lsp-analysis
+description: How to use Claude Code's built-in LSP tools for precise dependency analysis. Availability checking, graph reasoning, graceful degradation, and per-language server reference.
+---
+
+# LSP-Enhanced Analysis
+
+Claude Code provides built-in LSP (Language Server Protocol) tools that give you semantic code understanding — actual dependency graphs instead of text pattern matching. When LSP is available, use it. When it's not, fall back to grep/glob silently.
+
+This skill applies to any agent that performs code analysis — coupling, test coverage, architecture boundaries, migration scoping, or structural understanding.
+
+---
+
+## LSP Operations
+
+| Operation | What it does | Use it for |
+|-----------|-------------|------------|
+| `find-references` | Find all usages of a symbol across the workspace | Dependency mapping, counting consumers of exports, detecting cross-boundary calls |
+| `call-hierarchy` (incoming) | Find all functions that call the target function | Afferent coupling — who depends on this? Blast radius of a change |
+| `call-hierarchy` (outgoing) | Find all functions the target function calls | Efferent coupling — what does this depend on? Transitive dependency depth |
+| `go-to-definition` | Jump to where a symbol is defined | Resolving what an imported symbol actually is, following re-exports |
+| `hover` | Get type information and documentation for a symbol | Type info for complexity assessment, understanding interfaces without reading source |
+| `document-symbols` | List all symbols in a file (functions, classes, interfaces) | Module structure overview, listing exports, quick structural scan |
+| `workspace-symbols` | Search for symbols by name across the entire workspace | Finding types, interfaces, or classes by name across the codebase |
+
+---
+
+## Graph Reasoning
+
+LSP responses are **graph edges**, not search results. Each `find-references` call returns edges in a dependency graph. Each `call-hierarchy` call returns paths through that graph. Build the graph, then reason over it.
+
+**Transitivity.** Don't stop at direct callers or callees. Use call-hierarchy to follow chains. If A calls B and B calls C, then A depends on C. Grep only shows you A→B and B→C as separate matches — LSP gives you the chain directly.
+
+**Completeness.** `find-references` returns ALL usages, not a sample. Count them. "3 callers" vs "47 callers" is the difference between loosely coupled and tightly coupled. Grep misses re-exports, aliased imports, inherited methods, and framework-injected references.
+
+**Quantify coupling with fan-in and fan-out.**
+- Fan-in = incomingCalls count. How many things depend on this symbol? High fan-in means changes here propagate widely.
+- Fan-out = outgoingCalls count. How many things does this symbol depend on? High fan-out means this is fragile — many reasons for it to break.
+
+**Blast radius** = incomingCalls depth. How far does a change propagate through the call graph? A function with 3 direct callers might have 50 transitive dependents.
+
+**Testability** = outgoingCalls depth. How many things must be mocked or stubbed to test this in isolation? A function with 1 import but 15 transitive outgoing calls is not a low-hanging fruit for unit testing.
+
+**Why this matters more than grep.** Grep finds text matches. LSP finds semantic connections. Grep misses:
+- Re-exported symbols used under a different name
+- Inherited methods called on a subclass
+- Framework-injected dependencies (decorators, annotations, DI containers)
+- Dynamic dispatch through interfaces or abstract classes
+
+When you have LSP data, reason over the graph structure. When you don't, acknowledge that grep-based analysis is an approximation.
+
+---
+
+## Availability Check
+
+Check LSP availability once at the start of your analysis, not per-operation.
+
+1. Early in your analysis, attempt `document-symbols` on one of the target files.
+2. If it returns symbols: LSP is available. Use LSP operations for the rest of your analysis.
+3. If it fails or returns nothing: LSP is not available. Use grep/glob for all analysis steps.
+
+Decide once. Don't retry LSP after it fails — repeated failures waste time and add noise. Set a flag and move on.
+
+---
+
+## Graceful Degradation
+
+When LSP is not available:
+
+- **Do not error.** Do not warn during analysis. Fall back silently to grep/glob — the same analysis the agent did before LSP existed.
+- **Every LSP-enhanced step must have a grep fallback.** If the agent used `find-references` for dependency mapping, the fallback is `Grep` for import/require patterns. If it used `call-hierarchy` for coupling depth, the fallback is reading files and tracing calls manually.
+- **Note at the end of output.** After the analysis is complete, add: "Note: LSP was not available for this analysis. Results use text-based pattern matching. For more accurate dependency analysis, consider configuring a language server — see the language server reference table below."
+- **Reference the language table** so the developer knows which server to explore for their ecosystem.
+
+---
+
+## Output Signaling
+
+Include one of these phrases in your analysis output so the developer knows the confidence level:
+
+- **When LSP was used:** "Analysis method: LSP-enhanced analysis"
+- **When LSP was not available:** "Analysis method: text-based pattern matching"
+
+Place this near the top of the output, before the findings. This is a single line — not a paragraph, not a disclaimer.
+
+---
+
+## Language Server Reference
+
+| Language | LSP Server |
+|----------|-----------|
+| TypeScript / JavaScript | typescript-language-server |
+| Java | jdtls (Eclipse JDT Language Server) |
+| Go | gopls |
+| Python | pyright |
+| Rust | rust-analyzer |
+| C / C++ | clangd |
+| Ruby | solargraph |
+| C# | omnisharp |
+| Kotlin | kotlin-language-server |
+| PHP | intelephense |
+| Swift | sourcekit-lsp |

--- a/docs/specs/lsp-integration-discovery.md
+++ b/docs/specs/lsp-integration-discovery.md
@@ -1,0 +1,170 @@
+# Discovery: LSP-Enhanced Analysis Agents
+
+## Why
+
+Bee's analysis agents rely on grep and glob to understand code structure -- import patterns, dependency graphs, module boundaries. This works for surface-level analysis but produces inaccurate results when the real dependency picture is more complex than what text patterns reveal. When Bee says "this is a low-hanging fruit" and it turns out to be a dependency hell, developers stop trusting the recommendations. Accuracy is what upholds Bee's reputation. If recommendations are mostly wrong, people start ignoring them -- and then Bee is just noise.
+
+Claude Code already has built-in LSP support (since v2.0.74) with go-to-definition, find-references, and hover documentation. Language server lifecycle is managed automatically. This means Bee can get precise dependency graphs without building infrastructure, adopting third-party servers, or adding runtime code. The agents just need updated instructions to use LSP tools when available.
+
+## Who
+
+<!-- -------- bee-comment -------- -->
+> **@developer**: is there a way that instead of talking about specific command we make it more generic? either we can add it to skills, or rather say that whatever commands bee adds, if it involves code analysis, and if a LSP exists then it will use LSP and a knowledge graph, otherwise it will fallback, and tell it to the end user to explore the relevant lsp
+> **@bee**: Reframed the entire approach. Instead of per-command LSP integration, this is now a **skill** (`bee/skills/lsp-analysis/SKILL.md`) that any agent doing code analysis can reference. The "Who" section now describes any Bee agent, not specific commands. The Design Philosophy and Milestone Map are updated to reflect the skill-first architecture — the skill defines when/how to use LSP, and agents just reference it like they reference `clean-code` or `tdd-practices`.
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+
+**Any Bee agent that performs code analysis.** Today that's the agents behind `/bee:qc`, `/bee:review`, `/bee:architect`, and `/bee:migrate`. Tomorrow it's whatever new commands Bee adds. The LSP integration is a **skill** — shared reference knowledge at `bee/skills/lsp-analysis/SKILL.md` — not a per-command feature. Any agent that involves code analysis references this skill and gets LSP-enhanced accuracy automatically.
+
+**Developers using Bee** -- they need recommendations they can trust. When Bee says "these modules are independent," that must be true. When it says "easy to unit test," it must actually be easy.
+
+**Tech leads evaluating Bee** -- if early recommendations are wrong, trust is lost and adoption stalls. Accuracy on first contact matters disproportionately.
+
+## Design Philosophy
+
+This is an accuracy enhancement, not a feature addition. The agents already do the right analysis -- they just do it with imprecise tools. LSP gives them precise tools. The wingman philosophy applies: better data in, better recommendations out, same digestible output.
+
+Bee stays pure-markdown. No runtime code, no MCP servers to build, no infrastructure to maintain. The LSP integration lives as a **skill** (`bee/skills/lsp-analysis/SKILL.md`) — the same pattern as `clean-code`, `tdd-practices`, and `code-review`. Any agent that does code analysis references this skill. The skill defines: which LSP operations to use, how to check availability, the graceful degradation pattern, and what to tell the end user about configuring a language server. Agents don't need to reinvent this — they just follow the skill.
+
+When LSP is not available, agents fall back silently to grep-based analysis — the current behavior — with a note in the output suggesting the user explore the relevant LSP for their language.
+
+## Success Criteria
+
+- When LSP is available, the review-coupling agent produces dependency graphs that include indirect dependencies (call chains, type hierarchies) -- not just direct import statements
+- Developers stop encountering "this looked simple but turned into a cascade" surprises from Bee's coupling analysis
+- The QC planner's "low-hanging fruit" assessments reflect actual testability -- accounting for hidden dependencies, inherited methods, and framework-injected coupling
+- Migration ordering recommendations account for indirect coupling, not just import-level dependencies
+- When LSP is unavailable, every agent works exactly as it does today -- no regressions, no failures
+- Agent output includes a clear signal about whether LSP was used, so developers understand the confidence level of the analysis
+
+## Problem Statement
+
+Bee's analysis agents use text-based pattern matching (grep for imports, glob for file structure) to build dependency graphs and assess code relationships. This approach has a fundamental blind spot: it sees what files say they import, but not what they actually depend on through call chains, type hierarchies, interface implementations, and framework-level coupling.
+
+This blind spot causes three concrete problems:
+1. **Coupling blindness** -- the coupling agent says "these modules are independent" when they share deep call chains through shared abstractions
+2. **Hidden test dependencies** -- the QC planner says "easy to unit test" when the function depends on framework-injected services, inherited methods, or dynamic dispatch that makes isolation hard
+3. **Wrong migration order** -- the migrate command says "move this module first, it has few dependencies" but misses indirect coupling, creating rework
+
+All three trace to the same root cause: not knowing the real dependency graph. LSP provides that graph through find-references, call-hierarchy, and type information.
+
+## Hypotheses
+
+- H1: Claude Code's built-in LSP tools (find-references, call-hierarchy, hover) provide sufficient semantic precision to replace grep-based dependency analysis in the review-coupling agent -- no additional tooling needed.
+- H2: Improving dependency graph accuracy in review-coupling will have a multiplier effect on QC and migrate, since both consume coupling data to make prioritization decisions.
+- H3: The primary LSP operations needed across all agents are find-references and call-hierarchy. Go-to-definition and hover are useful but secondary.
+- H4: Most projects that would benefit from LSP-enhanced analysis already have a language server available (TypeScript, Java, Python, Go all have mature LSP implementations) -- the barrier is .mcp.json configuration, not language server availability.
+- H5: Silent degradation (fall back to grep, note in output) is sufficient -- developers do not need an interactive setup wizard for LSP configuration.
+
+## Out of Scope
+
+- Building or adopting MCP-LSP bridge servers -- Claude Code's built-in LSP support eliminates this need
+- Adding runtime code to Bee -- the plugin stays pure-markdown
+- Tree-sitter integration -- LSP provides the semantic precision we need; tree-sitter's structural analysis is a separate concern for potential future exploration
+- Language server installation or management -- Bee uses whatever LSP is configured in .mcp.json; it does not install language servers
+- Interactive LSP setup wizard -- if LSP is not configured, Bee notes it in output and continues with grep
+- Modifying LSP tool behavior in Claude Code itself -- we consume LSP as a tool, we do not extend it
+
+## Graceful Degradation Pattern
+
+Every agent that uses LSP follows the same pattern:
+
+1. **Check availability**: attempt an LSP operation early in the analysis (e.g., find-references on a known file)
+2. **If available**: use LSP for dependency analysis, note "LSP-enhanced analysis" in output
+3. **If unavailable**: fall back to current grep/glob approach with no behavior change
+4. **Note in output**: "Note: LSP was not available for this analysis. Results use text-based pattern matching. For more accurate dependency analysis, configure a language server in .mcp.json."
+
+This pattern is universal across all agents. LSP is an enhancement, never a requirement.
+
+## Milestone Map
+
+### Phase 0: Create the LSP analysis skill
+
+Create `bee/skills/lsp-analysis/SKILL.md` — the shared reference that any code-analysis agent can draw on. This skill defines:
+
+- **Available LSP operations**: find-references, call-hierarchy, go-to-definition, hover, document-symbols, workspace-symbols, diagnostics
+- **When to use each**: find-references for dependency mapping, call-hierarchy for transitive dependency depth, hover for type information, document-symbols for module structure
+- **Availability check pattern**: attempt a lightweight LSP operation early; if it fails, set a flag and use grep for the rest of the analysis
+- **Graceful degradation**: fall back to grep/glob, add a note in output telling the user which language server to explore for their ecosystem
+- **Output signaling**: "LSP-enhanced analysis" vs "text-based pattern matching" so developers know the confidence level
+- **Per-language LSP recommendations**: a reference table mapping common languages to their LSP servers (typescript-language-server, jdtls, gopls, pyright, rust-analyzer, etc.) for the degradation note
+
+**Done when:** the skill file exists and can be referenced by any agent. No agent changes yet.
+
+### Phase 1: review-coupling references the skill (walking skeleton)
+
+This is the highest-value, lowest-risk starting point. The review-coupling agent already has a clear "Map Dependencies" step that says "use Grep to find import patterns." LSP find-references is the direct upgrade.
+
+**What changes in the agent instructions:**
+
+- Add a reference to the `lsp-analysis` skill
+- **Step 1 (Map Dependencies)**: before grepping for imports, follow the skill's availability check. If LSP responds, use find-references on key exports to build the dependency graph from actual reference data. If not, fall back to grep.
+- **Step 2 (Afferent Coupling)**: use find-references to count actual consumers of a module's exports -- not just files that import it, but files that call its functions.
+- **Step 3 (Efferent Coupling)**: use call-hierarchy (outgoing calls) to map what a module actually reaches into, including transitive dependencies through shared abstractions.
+- **Step 5 (Boundary Violations)**: use find-references to detect cross-boundary calls that grep misses -- e.g., a domain function called from infrastructure through an intermediary.
+
+**LSP operations used:**
+- `find-references` -- who actually uses this symbol?
+- `call-hierarchy` (outgoing) -- what does this function call, transitively?
+
+**What stays the same:**
+- Output format (unchanged -- same markdown structure)
+- Categorization logic (Critical/Suggestion/Nitpick)
+- The agent's role as a read-only analyst
+- All grep-based analysis as the fallback path
+
+**Done when:**
+- review-coupling produces more accurate dependency graphs on a project with LSP configured vs the same project without
+- The agent degrades gracefully when LSP is absent
+- Output clearly signals whether LSP was used
+
+### Phase 2: review-tests + QC planner (test accuracy)
+
+Builds on Phase 1. The QC planner already consumes coupling data -- Phase 1 makes that data better. Phase 2 adds LSP awareness to the test agent directly.
+
+- **review-tests**: use find-references from test files back to source to map actual test coverage. Detect which public functions have zero references from any test file. This makes "no tests" vs "partial tests" assessment precise instead of heuristic.
+- **qc-planner**: when assessing testability ("is this a low-hanging fruit?"), use call-hierarchy to check how deep the dependency chain goes. A function that calls 3 other functions which each call 3 more is not a low-hanging fruit, even if it only has one direct import.
+
+**LSP operations used:**
+- `find-references` -- which source functions are referenced from test files?
+- `call-hierarchy` (outgoing) -- how deep is the dependency chain for this function?
+
+### Phase 3: context-gatherer + domain-language-extractor (structural understanding)
+
+- **context-gatherer**: use document-symbols and workspace-symbols for language-aware module detection. Instead of inferring architecture from folder names, detect actual class hierarchies, interface implementations, and module exports.
+- **domain-language-extractor**: use hover for type definitions and document-symbols for interface/type names. Vocabulary extraction from the actual type system instead of grepping for class declarations.
+
+**LSP operations used:**
+- `document-symbols` -- what symbols does this file export?
+- `workspace-symbols` -- find symbols by name across the project
+- `hover` -- get type information for a symbol
+
+### Phase 4: architecture-test-writer (boundary validation)
+
+- **architecture-test-writer**: use find-references to validate boundary assertions with real dependency data. When generating a test like "orders module should not import from payments internals," verify with find-references that the boundary actually holds (or doesn't), rather than relying on grep for import statements.
+
+**LSP operations used:**
+- `find-references` -- validate that no symbol from module A is referenced in module B
+
+### Phase 5 (future): review-code-quality (diagnostics and type-aware quality)
+
+- **review-code-quality**: use LSP diagnostics for compiler warnings/errors, hover for type information when assessing complexity. This is the least urgent enhancement -- the code quality agent's grep-based analysis is less affected by the dependency blind spot than the other agents.
+
+**LSP operations used:**
+- `hover` -- type information for complexity assessment
+- Diagnostics -- compiler-level warnings the agent currently cannot see
+
+## Open Questions
+
+- Which specific LSP operations does Claude Code's built-in support expose? The discovery identified find-references, go-to-definition, and hover. Call-hierarchy support needs to be verified -- it is critical for Phase 1.
+- How does Claude Code's LSP handle multi-language projects? Does each language need its own entry in .mcp.json, and do agents need to detect which language server to query for a given file?
+- What is the latency profile of LSP operations within Claude Code? If find-references takes several seconds per symbol, agents may need to be selective about which symbols they query rather than querying everything.
+- Should the graceful degradation note recommend specific language servers per ecosystem (e.g., "For TypeScript projects, configure typescript-language-server in .mcp.json")? Or keep it generic?
+- How do we measure accuracy improvement? Is there a way to compare "grep-based dependency graph" vs "LSP-based dependency graph" on a real project to validate H1 before rolling out to all agents?
+
+## Revised Assessment
+
+Size: FEATURE -- Phase 1 is a markdown-only change to one agent (review-coupling). No runtime code, no infrastructure. Later phases follow the same pattern. The work is in writing precise agent instructions, not building systems.
+Greenfield: no -- this enhances existing agents within an established plugin architecture.
+
+[s] Reviewed

--- a/docs/specs/lsp-integration-spec.md
+++ b/docs/specs/lsp-integration-spec.md
@@ -1,0 +1,94 @@
+# Spec: LSP-Enhanced Analysis
+
+## Overview
+
+Add an `lsp-analysis` skill that teaches any Bee agent to use Claude Code's built-in LSP operations for precise dependency analysis, with graceful degradation to grep when LSP is unavailable. Then integrate the skill into each code-analysis agent incrementally.
+
+All changes are markdown-only. Bee stays pure-markdown -- no runtime code.
+
+## Slice 0: LSP Analysis Skill
+
+Create `bee/skills/lsp-analysis/SKILL.md` -- the shared reference for all code-analysis agents.
+
+- [x]Skill file exists at `bee/skills/lsp-analysis/SKILL.md` with standard frontmatter (name, description)
+- [x]Documents available LSP operations: find-references, call-hierarchy (incoming + outgoing), go-to-definition, hover, document-symbols, workspace-symbols
+- [x]Describes when to use each operation (find-references for dependency mapping, call-hierarchy for transitive depth, hover for type info, document-symbols for module structure)
+- [x]Defines the availability check pattern: attempt a lightweight LSP operation early in analysis; if it fails, fall back to grep for the rest
+- [x]Defines the graceful degradation pattern: fall back silently to grep/glob, add a note in output telling the user which language server to explore
+- [x]Defines output signaling: "LSP-enhanced analysis" when LSP was used, "text-based pattern matching" when it was not
+- [x]Includes a per-language reference table mapping languages to LSP server names (typescript-language-server, jdtls, gopls, pyright, rust-analyzer, clangd, solargraph, etc.)
+- [x]Includes a "Graph Reasoning" section teaching agents how to use LSP data as a knowledge graph — LSP responses are graph edges not search results, build the graph then reason over it, use transitivity (follow call chains, don't stop at direct callers), quantify coupling by counting references, blast radius = incomingCalls depth, testability = outgoingCalls depth
+- [x]Does not include .mcp.json configuration snippets -- names only
+
+## Slice 1: review-coupling (walking skeleton)
+
+Update `bee/agents/review-coupling.md` to reference the skill and use LSP when available.
+
+- [x]Agent references `skills/lsp-analysis/SKILL.md` in its Skills section
+- [x]Agent lists LSP tools in its frontmatter tools list (alongside Read, Glob, Grep)
+- [x]Step 1 (Map Dependencies): before grepping imports, follows the skill's availability check; if LSP responds, uses find-references on key exports to build the dependency graph
+- [x]Step 2 (Afferent Coupling): uses find-references to count actual consumers of a module's exports, not just files that import it
+- [x]Step 3 (Efferent Coupling): uses call-hierarchy (outgoing) to map transitive dependencies through shared abstractions
+- [x]Step 5 (Boundary Violations): uses find-references to detect cross-boundary calls that grep misses
+- [x]Each step retains the existing grep-based approach as the fallback when LSP is unavailable
+- [x]Output format is unchanged -- same markdown structure, same categorization (Critical/Suggestion/Nitpick)
+- [x]Output includes the skill's signaling note indicating whether LSP or text-based matching was used
+
+## Slice 2: review-tests + qc-planner
+
+Update both agents to reference the skill and use LSP for test coverage and testability assessment.
+
+- [x]`review-tests.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+- [x]review-tests Step 5 (Coverage Gaps): uses find-references from test files back to source to detect which public functions have zero test references
+- [x]`qc-planner.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+- [x]qc-planner Step 3 (Assess Testability): uses call-hierarchy (outgoing) to measure dependency chain depth when judging whether something is a low-hanging fruit
+- [x]Both agents retain grep-based fallback for each LSP-enhanced step
+- [x]Both agents include the LSP/text-based signaling note in output
+
+## Slice 3: context-gatherer + domain-language-extractor
+
+Update both agents to use LSP for structural understanding and vocabulary extraction.
+
+- [x]`context-gatherer.md` references the skill in its Skills section
+- [x]context-gatherer uses document-symbols and workspace-symbols for language-aware module detection instead of relying solely on folder names
+- [x]`domain-language-extractor.md` references the skill in its Skills section
+- [x]domain-language-extractor Step 3 (Infer Vocabulary from Code): uses hover for type definitions and document-symbols for interface/type names
+- [x]Both agents retain grep-based fallback
+- [x]Both agents include the signaling note in output
+
+## Slice 4: architecture-test-writer
+
+Update the agent to use LSP for boundary validation.
+
+- [x]`architecture-test-writer.md` references the skill in its Skills section
+- [x]Steps 3-4 (Generate Passing/Failing Tests): uses find-references to validate boundary assertions with real dependency data instead of grep for import statements
+- [x]Retains grep-based fallback
+- [x]Includes the signaling note in output
+
+## Slice 5: review-code-quality
+
+Update the agent to use LSP for type-aware quality analysis.
+
+- [x]`review-code-quality.md` references the skill in its Skills section
+- [x]Step 2 (Review Each File): uses hover for type information when assessing complexity, and LSP diagnostics for compiler-level warnings
+- [x]Retains grep-based fallback
+- [x]Includes the signaling note in output
+
+## Out of Scope
+
+- Building or adopting MCP-LSP bridge servers
+- Adding runtime code to Bee
+- Tree-sitter integration
+- Language server installation or management
+- Interactive LSP setup wizard
+- .mcp.json configuration examples in the skill
+- Modifying LSP tool behavior in Claude Code itself
+
+## Technical Context
+
+- **Patterns to follow**: existing skill format (see `bee/skills/clean-code/SKILL.md` for structure); existing agent format with frontmatter, Skills section, Process steps, Output Format, Rules
+- **Key dependencies**: Claude Code built-in LSP (find-references ~50ms/query, call-hierarchy confirmed available, hover, document-symbols, workspace-symbols)
+- **Integration point**: each agent already has a Skills section where references are added, and a Process section where steps get the LSP-first-then-grep pattern
+- **Risk level**: LOW -- all changes are markdown instruction edits to existing files, plus one new skill file
+
+[x] Reviewed

--- a/docs/specs/lsp-slice-0-tdd-plan.md
+++ b/docs/specs/lsp-slice-0-tdd-plan.md
@@ -1,0 +1,209 @@
+# TDD Plan: LSP Analysis Skill -- Slice 0
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/lsp-integration-spec.md`
+- **Slice**: Slice 0 -- LSP Analysis Skill
+- **Risk**: LOW
+- **Nature**: Markdown-only skill file. No runtime code. Each "behavior" is a verifiable section of content.
+
+## Codebase Analysis
+
+### File Structure
+- Implementation: `bee/skills/lsp-analysis/SKILL.md` (new file)
+- Tests: Manual verification -- content checks against ACs
+- Related files: All existing skills follow the same pattern (frontmatter + H1 + H2 sections)
+
+### Existing Skill Pattern
+Every skill file has:
+1. YAML frontmatter with `name` and `description`
+2. An H1 title matching the skill's purpose
+3. H2 sections for each concept area
+4. Actionable, prescriptive prose (tells the agent what to do)
+5. No code blocks unless demonstrating code patterns
+
+### Verification Method
+Since this is markdown, "RED" means writing a content requirement, "GREEN" means writing the content that satisfies it, and "REFACTOR" means tightening the prose. Each step's pass/fail is verified by reading the file and confirming the AC is met.
+
+---
+
+## Behavior 1: Skill file exists with standard frontmatter
+
+**Given** the skill directory `bee/skills/lsp-analysis/` does not exist
+**When** we create `SKILL.md`
+**Then** the file has YAML frontmatter with `name: lsp-analysis` and a `description` field, plus an H1 title
+
+- [x] **RED**: Confirm `bee/skills/lsp-analysis/SKILL.md` does not exist
+- [x] **GREEN**: Create the file with frontmatter and H1 title
+  - `name: lsp-analysis`
+  - `description`: one-line summary of what the skill teaches agents
+  - H1: something like "LSP-Enhanced Analysis"
+  - Follow the exact frontmatter format from `bee/skills/clean-code/SKILL.md`
+- [x] **VERIFY**: File exists, frontmatter parses correctly, H1 is present
+
+---
+
+## Behavior 2: Documents available LSP operations
+
+**Given** the skill file exists with frontmatter
+**When** we add the operations reference section
+**Then** it lists all six LSP operations with a brief description of each
+
+- [x] **RED**: Confirm no LSP operations section exists yet
+- [x] **GREEN**: Add an H2 section listing each operation with a one-line description:
+  - `find-references` -- find all usages of a symbol across the workspace
+  - `call-hierarchy` (incoming) -- who calls this function
+  - `call-hierarchy` (outgoing) -- what does this function call
+  - `go-to-definition` -- jump to where a symbol is defined
+  - `hover` -- get type information and documentation for a symbol
+  - `document-symbols` -- list all symbols in a file (functions, classes, interfaces)
+  - `workspace-symbols` -- search for symbols across the entire workspace
+- [x] **VERIFY**: All six operations (with call-hierarchy split into incoming/outgoing) are documented
+- [x] **REFACTOR**: Ensure descriptions are concise and action-oriented
+
+---
+
+## Behavior 3: Describes when to use each operation
+
+**Given** the operations are listed
+**When** we add usage guidance
+**Then** each operation has a "when to use" context mapped to analysis tasks
+
+- [x] **RED**: Confirm no usage guidance exists yet
+- [x] **GREEN**: Add an H2 section (or extend the operations section) with guidance:
+  - `find-references` -- dependency mapping, counting consumers of exports, detecting cross-boundary calls
+  - `call-hierarchy` (incoming) -- understanding who depends on a function, afferent coupling
+  - `call-hierarchy` (outgoing) -- transitive dependency depth, efferent coupling
+  - `go-to-definition` -- resolving what an imported symbol actually is
+  - `hover` -- type info for complexity assessment, understanding interfaces without reading source
+  - `document-symbols` -- module structure overview, listing exports
+  - `workspace-symbols` -- finding types/interfaces by name across the codebase
+- [x] **VERIFY**: Each operation has clear "use this when..." guidance
+- [x] **REFACTOR**: Remove any overlap or redundancy between operation descriptions and usage guidance -- consider combining into a single reference if cleaner
+
+---
+
+## Behavior 4: Graph reasoning guidance
+
+**Given** the operations and usage guidance exist
+**When** we add graph reasoning guidance
+**Then** agents understand that LSP data is a knowledge graph, not search results, and know how to reason over it
+
+- [x] **RED**: Confirm no graph reasoning section exists yet
+- [x] **GREEN**: Add an H2 section teaching agents the mental model:
+  - LSP responses are **graph edges**, not search results. Each findReferences call returns edges in a dependency graph. Build the graph, then reason over it.
+  - **Transitivity**: don't stop at direct callers/callees. Use call-hierarchy to follow chains. A → B → C means A depends on C.
+  - **Completeness**: findReferences returns ALL usages, not a sample. Count them. "3 callers" vs "47 callers" is the difference between loosely and tightly coupled.
+  - **Quantify coupling**: fan-in (incomingCalls count) = how many things depend on this. Fan-out (outgoingCalls count) = how many things this depends on.
+  - **Blast radius** = incomingCalls depth. How far does a change propagate?
+  - **Testability** = outgoingCalls depth. How many things must be mocked/stubbed to test in isolation?
+  - Contrast with grep: grep finds text matches, LSP finds semantic connections. Grep misses re-exports, aliased imports, inherited methods, framework injection.
+- [x] **VERIFY**: An agent reading this section would reason over LSP data as a graph, not use findReferences like a fancy grep
+- [x] **REFACTOR**: Keep it concise — this is a mental model, not a tutorial
+
+---
+
+## Behavior 5: Defines the availability check pattern
+
+**Given** the operations, usage guidance, and graph reasoning guidance exist
+**When** we add the availability check pattern
+**Then** agents know to attempt a lightweight LSP call early and branch based on success/failure
+
+- [x] **RED**: Confirm no availability check pattern exists yet
+- [x] **GREEN**: Add an H2 section defining the pattern:
+  - Early in analysis, attempt one lightweight LSP operation (e.g., `document-symbols` on the target file)
+  - If it succeeds: LSP is available, use LSP operations for the rest of the analysis
+  - If it fails: LSP is not available, fall back to grep/glob for the rest
+  - Key point: decide once at the start, not per-operation (avoids repeated failures)
+- [x] **VERIFY**: Pattern is clear enough that an agent can follow it mechanically
+
+---
+
+## Behavior 6: Defines the graceful degradation pattern
+
+**Given** the availability check pattern exists
+**When** we add the degradation pattern
+**Then** agents know to fall back silently and inform the user about language server options
+
+- [x] **RED**: Confirm no degradation section exists yet
+- [x] **GREEN**: Add an H2 section (or subsection) defining:
+  - Fall back silently -- do not error, do not warn during analysis
+  - Use grep/glob as the fallback for every LSP-enhanced step
+  - At the end of output, add a note telling the user which language server they could install for better results
+  - Reference the per-language table (Behavior 7) for the server name
+- [x] **VERIFY**: Degradation is silent during analysis, informative at the end
+
+---
+
+## Behavior 7: Defines output signaling
+
+**Given** the degradation pattern exists
+**When** we add output signaling
+**Then** agents know the exact phrases to include in their output
+
+- [x] **RED**: Confirm no output signaling section exists yet
+- [x] **GREEN**: Add a section defining the two signal phrases:
+  - When LSP was used: include "LSP-enhanced analysis" in the output
+  - When LSP was not available: include "text-based pattern matching" in the output
+  - Specify where in the output this goes (e.g., a note at the top or bottom of the analysis)
+- [x] **VERIFY**: Both exact phrases are documented, placement is clear
+
+---
+
+## Behavior 8: Per-language reference table
+
+**Given** all patterns are defined
+**When** we add the language server reference
+**Then** a table maps languages to their LSP server names
+
+- [x] **RED**: Confirm no language table exists yet
+- [x] **GREEN**: Add an H2 section with a markdown table:
+  - TypeScript/JavaScript -> typescript-language-server
+  - Java -> jdtls
+  - Go -> gopls
+  - Python -> pyright
+  - Rust -> rust-analyzer
+  - C/C++ -> clangd
+  - Ruby -> solargraph
+  - (Add 2-3 more common ones if appropriate: C# -> omnisharp, Kotlin -> kotlin-language-server, etc.)
+- [x] **VERIFY**: Table is present, maps languages to server names only (no config snippets)
+
+---
+
+## Behavior 9: No .mcp.json configuration snippets
+
+**Given** the complete skill file
+**When** we review the entire content
+**Then** there are zero .mcp.json examples, zero configuration snippets -- server names only
+
+- [x] **RED**: Search the file for `.mcp.json`, `configuration`, JSON code blocks
+- [x] **VERIFY**: None found. The file references server names but never shows how to configure them.
+
+---
+
+## Final Check
+
+- [x] **Read the complete file top to bottom**: Does it flow logically? (operations -> when to use -> graph reasoning -> check pattern -> degradation -> signaling -> language table)
+- [x] **Check against all 9 ACs from the spec**: Each one is satisfied
+- [x] **Check tone**: Prescriptive and actionable, matching the style of existing skills (clean-code, tdd-practices)
+- [x] **Check length**: Concise -- no padding, no repetition. A skill file should be a quick reference, not a tutorial.
+
+## Verification Summary
+| AC | Description | Verified |
+|----|-------------|----------|
+| 1 | Skill file exists with standard frontmatter | ✅ |
+| 2 | Documents all LSP operations | ✅ |
+| 3 | Describes when to use each operation | ✅ |
+| 4 | Graph reasoning guidance | ✅ |
+| 5 | Availability check pattern | ✅ |
+| 6 | Graceful degradation pattern | ✅ |
+| 7 | Output signaling phrases | ✅ |
+| 8 | Per-language reference table | ✅ |
+| 9 | No .mcp.json config snippets | ✅ |
+
+[x] Reviewed

--- a/docs/specs/lsp-slice-1-tdd-plan.md
+++ b/docs/specs/lsp-slice-1-tdd-plan.md
@@ -1,0 +1,209 @@
+# TDD Plan: LSP-Enhanced review-coupling -- Slice 1
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/lsp-integration-spec.md`, Slice 1
+- **Slice**: review-coupling gets LSP-enhanced analysis
+- **Risk**: LOW
+- **Nature**: Markdown-only edit to an existing agent file. No runtime code.
+- **Acceptance Criteria**:
+  1. Agent references `skills/lsp-analysis/SKILL.md` in its Skills section
+  2. Agent lists LSP tools in its frontmatter tools list
+  3. Step 1 (Map Dependencies): LSP availability check, then find-references for dependency graph
+  4. Step 2 (Afferent Coupling): find-references to count actual consumers
+  5. Step 3 (Efferent Coupling): call-hierarchy (outgoing) for transitive dependencies
+  6. Step 5 (Boundary Violations): find-references for cross-boundary calls
+  7. Each step retains grep-based fallback when LSP is unavailable
+  8. Output format unchanged -- same markdown structure, same categorization
+  9. Output includes signaling note (LSP-enhanced or text-based)
+
+## Codebase Analysis
+
+### File Structure
+- Implementation: `bee/agents/review-coupling.md`
+- Skill reference: `bee/skills/lsp-analysis/SKILL.md` (already exists)
+- No runtime tests exist in this project -- all deliverables are markdown agent files
+
+### Verification Method
+Since this is a markdown-only change, each "test" is a structural verification: grep or read the file and confirm the expected content exists. The RED phase describes what to look for that does NOT yet exist. The GREEN phase adds it. The verification confirms it.
+
+### Current File Structure (review-coupling.md)
+- Frontmatter: `tools: Read, Glob, Grep`
+- Skills section: references only `skills/code-review/SKILL.md`
+- Process: Steps 1-5 (Map Dependencies, Afferent, Efferent, Change Amplifiers, Boundary Violations) + Step 6 (Categorize)
+- Output Format: markdown template with Working Well + Findings
+- Rules: read-only, no sub-agents, coupling guidance
+
+---
+
+## Behavior 1: Skill reference added to Skills section
+
+**Given** the current Skills section references only `skills/code-review/SKILL.md`
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/review-coupling.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a second bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced dependency analysis, availability checking, graceful degradation`
+  - Keep the existing code-review skill reference unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 2: LSP tools added to frontmatter
+
+**Given** the frontmatter has `tools: Read, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Glob, Grep, mcp__lsp__find-references, mcp__lsp__call-hierarchy, mcp__lsp__document-symbols`
+  - Note: use the exact tool naming convention from the skill file. If the project uses a different MCP tool naming pattern, match that instead.
+
+- [x] **VERIFY**: The `tools:` line contains both original tools and LSP tools
+
+---
+
+## Behavior 3: Step 1 gets LSP availability check + find-references path
+
+**Given** Step 1 (Map Dependencies) currently only uses Grep for import patterns
+**When** the agent file is updated
+**Then** Step 1 first performs the availability check from the skill, then uses find-references if LSP is available, with grep as fallback
+
+- [x] **RED**: Verify Step 1 has no mention of LSP, `document-symbols`, or `find-references`
+
+- [x] **GREEN**: Rewrite Step 1 to add LSP-first path
+  - Add availability check at the top of Step 1: attempt `document-symbols` on one target file; if it returns symbols, LSP is available for all subsequent steps
+  - Add LSP path: use `find-references` on key exports to build the dependency graph
+  - Keep existing grep instructions as the explicit fallback under a "Fallback" or "If LSP is not available" sub-section
+  - The availability result carries forward -- do not re-check in later steps
+
+- [x] **VERIFY**: Step 1 contains `document-symbols` (availability check), `find-references` (LSP path), and retains grep-based instructions as fallback
+
+---
+
+## Behavior 4: Step 2 gets find-references for afferent coupling
+
+**Given** Step 2 (Afferent Coupling) currently identifies dependents through general code inspection
+**When** the agent file is updated
+**Then** Step 2 uses find-references to count actual consumers of a module's exports
+
+- [x] **RED**: Verify Step 2 has no mention of `find-references`
+
+- [x] **GREEN**: Add LSP-first path to Step 2
+  - LSP path: use `find-references` on each module's exported symbols to count actual consumers (not just files that import it)
+  - Reference the skill's guidance: count references for fan-in, "3 callers vs 47 callers" distinction
+  - Fallback: retain existing grep-based approach for when LSP is unavailable
+
+- [x] **VERIFY**: Step 2 contains `find-references`, mentions counting consumers, and retains fallback
+
+---
+
+## Behavior 5: Step 3 gets call-hierarchy (outgoing) for efferent coupling
+
+**Given** Step 3 (Efferent Coupling) currently identifies dependencies through general inspection
+**When** the agent file is updated
+**Then** Step 3 uses call-hierarchy (outgoing) to map transitive dependencies
+
+- [x] **RED**: Verify Step 3 has no mention of `call-hierarchy`
+
+- [x] **GREEN**: Add LSP-first path to Step 3
+  - LSP path: use `call-hierarchy` (outgoing) to map transitive dependencies through shared abstractions
+  - Reference the skill's guidance: outgoingCalls depth measures fragility and testability
+  - Fallback: retain existing grep-based approach
+
+- [x] **VERIFY**: Step 3 contains `call-hierarchy`, mentions outgoing/transitive, and retains fallback
+
+---
+
+## Behavior 6: Step 5 gets find-references for boundary violations
+
+**Given** Step 5 (Boundary Violations) currently checks for imports that cross boundaries via code inspection
+**When** the agent file is updated
+**Then** Step 5 uses find-references to detect cross-boundary calls that grep misses
+
+- [x] **RED**: Verify Step 5 has no mention of `find-references`
+
+- [x] **GREEN**: Add LSP-first path to Step 5
+  - LSP path: use `find-references` on boundary-defining symbols (e.g., domain interfaces, public APIs) to detect cross-boundary calls that grep misses (re-exports, inherited methods, framework injection)
+  - Fallback: retain existing grep-based import checking
+
+- [x] **VERIFY**: Step 5 contains `find-references`, mentions cross-boundary detection, and retains fallback
+
+---
+
+## Behavior 7: Output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line from the skill
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line near the top of the output template: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+  - This matches the skill's Output Signaling section exactly
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Behavior 8: Output format structure and categorization unchanged
+
+**Given** the existing output format uses `## Structural Coupling Review`, `### Working Well`, `### Findings`, and `Critical/Suggestion/Nitpick` categorization
+**When** all changes are applied
+**Then** these structural elements remain exactly as they were
+
+- [x] **VERIFY**: Output Format still contains `## Structural Coupling Review`, `### Working Well`, `### Findings`, and `Critical/Suggestion/Nitpick`
+  - Read the full Output Format section and compare structure against the original
+
+---
+
+## Edge Cases (Low Risk)
+
+### Fallback consistency check
+- [x] **VERIFY**: Every step that gained an LSP path (Steps 1, 2, 3, 5) also has explicit fallback language
+  - Grep for "fallback" or "LSP is not available" or "If LSP" -- expect matches in Steps 1, 2, 3, and 5
+
+### No changes to unrelated sections
+- [x] **VERIFY**: Step 4 (Change Amplifiers) and Step 6 (Categorize) are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is
+
+### Rules section unchanged
+- [x] **VERIFY**: Rules section still contains all original rules (read-only, no sub-agents, coupling guidance)
+
+---
+
+## Final Check
+
+- [x] **Read the full file**: `bee/agents/review-coupling.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Glob, Grep + LSP tools
+- [x] **Skills**: references both code-review and lsp-analysis skills
+- [x] **Step 1**: availability check + find-references + grep fallback
+- [x] **Step 2**: find-references for consumer counting + grep fallback
+- [x] **Step 3**: call-hierarchy outgoing + grep fallback
+- [x] **Step 4**: unchanged
+- [x] **Step 5**: find-references for boundary detection + grep fallback
+- [x] **Step 6**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+- [x] **Rules**: unchanged
+
+## Verification Summary
+| Category | # Checks | Status |
+|----------|----------|--------|
+| Core behaviors (1-8) | 8 | ✅ |
+| Edge cases | 3 | ✅ |
+| Final check | 11 | ✅ |
+| **Total** | **22** | ✅ |
+
+[x] Reviewed

--- a/docs/specs/lsp-slice-2-tdd-plan.md
+++ b/docs/specs/lsp-slice-2-tdd-plan.md
@@ -1,0 +1,234 @@
+# TDD Plan: LSP-Enhanced review-tests + qc-planner -- Slice 2
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/lsp-integration-spec.md`, Slice 2
+- **Slice**: review-tests and qc-planner get LSP-enhanced analysis
+- **Risk**: LOW
+- **Nature**: Markdown-only edits to two existing agent files. No runtime code.
+- **Acceptance Criteria**:
+  1. `review-tests.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+  2. review-tests Step 5 (Coverage Gaps): uses find-references from test files back to source to detect which public functions have zero test references
+  3. `qc-planner.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+  4. qc-planner Step 3 (Assess Testability): uses call-hierarchy (outgoing) to measure dependency chain depth when judging whether something is a low-hanging fruit
+  5. Both agents retain grep-based fallback for each LSP-enhanced step
+  6. Both agents include the LSP/text-based signaling note in output
+
+## Codebase Analysis
+
+### File Structure
+- Implementation: `bee/agents/review-tests.md` and `bee/agents/qc-planner.md`
+- Skill reference: `bee/skills/lsp-analysis/SKILL.md` (already exists from Slice 0)
+- Pattern reference: `bee/agents/review-coupling.md` (already updated in Slice 1)
+- No runtime tests -- all deliverables are markdown agent files
+
+### Verification Method
+Since this is a markdown-only change, each "test" is a structural verification: grep or read the file and confirm the expected content exists. The RED phase describes what to look for that does NOT yet exist. The GREEN phase adds it. The verification confirms it.
+
+### Current File Structure (review-tests.md)
+- Frontmatter: `tools: Read, Glob, Grep`
+- Skills section: references only `skills/tdd-practices/SKILL.md`
+- Process: Steps 1-6 (Find Test Files, Behavior vs Implementation, Test Isolation, Test Naming, Coverage Gaps, Categorize)
+- Output Format: markdown template with Working Well + Findings
+- Rules: read-only, no sub-agents, test quality guidance
+
+### Current File Structure (qc-planner.md)
+- Frontmatter: `tools: Read, Write, Glob, Grep`
+- Skills section: references `skills/tdd-practices/SKILL.md` and `skills/clean-code/SKILL.md`
+- Process: Steps 1-5 (Compute Hotspot Scores, Cross-Reference, Assess Testability, Test Pyramid, Produce the Plan)
+- Output Format: fixed-format plan template with tables
+- Rules: no sub-agents, cap at 5-10, test pyramid priority, fixed format
+
+---
+
+## Behavior 1: Skill reference added to review-tests Skills section
+
+**Given** the review-tests Skills section references only `skills/tdd-practices/SKILL.md`
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/review-tests.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a second bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced analysis, availability checking, graceful degradation`
+  - Keep the existing tdd-practices skill reference unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 2: LSP tools added to review-tests frontmatter
+
+**Given** the review-tests frontmatter has `tools: Read, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Glob, Grep, mcp__lsp__find-references, mcp__lsp__document-symbols`
+  - Only the tools review-tests actually uses: find-references (for coverage gaps) and document-symbols (for availability check)
+
+- [x] **VERIFY**: The `tools:` line contains both original tools and the two LSP tools
+
+---
+
+## Behavior 3: review-tests Step 5 gets LSP availability check + find-references path
+
+**Given** Step 5 (Coverage Gaps) currently only uses qualitative assessment via reading source files
+**When** the agent file is updated
+**Then** Step 5 first performs the availability check, then uses find-references to trace from test files back to source functions, with the original approach as fallback
+
+- [x] **RED**: Verify Step 5 has no mention of LSP, `document-symbols`, or `find-references`
+
+- [x] **GREEN**: Rewrite Step 5 to add LSP-first path
+  - Add availability check at the top of Step 5: attempt `document-symbols` on one source file in scope; if it returns symbols, LSP is available for this step. Decide once; do not retry if it fails.
+  - Add LSP path: use `document-symbols` on source files to list public functions/methods, then use `find-references` on each to check whether any references come from test files. Public functions with zero test-file references are coverage gaps. This turns the qualitative assessment into a precise inventory.
+  - Keep the existing qualitative assessment instructions as the explicit fallback under a "Fallback (LSP unavailable)" sub-section -- the original bullets about error paths, edge cases, complex functions, and happy paths
+  - Preserve the closing line about qualitative assessment vs coverage percentage
+
+- [x] **VERIFY**: Step 5 contains `document-symbols` (availability check), `find-references` (LSP path), and retains the original qualitative assessment as fallback
+
+---
+
+## Behavior 4: review-tests output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line from the skill
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line after `## Test Quality Review` and before `### Working Well`: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Behavior 5: Skill reference added to qc-planner Skills section
+
+**Given** the qc-planner Skills section references `skills/tdd-practices/SKILL.md` and `skills/clean-code/SKILL.md`
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/qc-planner.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a third bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced analysis, availability checking, graceful degradation`
+  - Keep the existing tdd-practices and clean-code skill references unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 6: LSP tools added to qc-planner frontmatter
+
+**Given** the qc-planner frontmatter has `tools: Read, Write, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones (including Write)
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Write, Glob, Grep, mcp__lsp__call-hierarchy, mcp__lsp__document-symbols`
+  - Keep Write (qc-planner needs it to write the plan file)
+  - Only the tools qc-planner actually uses: call-hierarchy (for testability assessment) and document-symbols (for availability check)
+
+- [x] **VERIFY**: The `tools:` line contains Read, Write, Glob, Grep and the two LSP tools
+
+---
+
+## Behavior 7: qc-planner Step 3 gets LSP availability check + call-hierarchy path
+
+**Given** Step 3 (Assess Testability) currently identifies testability blockers through manual inspection of code patterns
+**When** the agent file is updated
+**Then** Step 3 first performs the availability check, then uses call-hierarchy (outgoing) to measure dependency chain depth, with the original approach as fallback
+
+- [x] **RED**: Verify Step 3 has no mention of LSP, `document-symbols`, or `call-hierarchy`
+
+- [x] **GREEN**: Rewrite Step 3 to add LSP-first path
+  - Add availability check at the top of Step 3: attempt `document-symbols` on one hotspot file; if it returns symbols, LSP is available for this step. Decide once; do not retry if it fails.
+  - Add LSP path: use `call-hierarchy` (outgoing) on public functions of each hotspot to measure dependency chain depth. A function with shallow outgoing calls (1-2 levels) is a low-hanging fruit for unit testing. A function with deep outgoing chains (many transitive dependencies) needs more mocking or refactoring before it can be tested in isolation. Reference the skill's guidance: "outgoingCalls depth measures testability."
+  - Keep the existing testability assessment instructions as the explicit fallback under a "Fallback (LSP unavailable)" sub-section -- the existing "Testable as-is" and "Needs refactoring first" blocks with all their bullet points
+  - Preserve the extensive refactoring rule about 4+ steps
+
+- [x] **VERIFY**: Step 3 contains `document-symbols` (availability check), `call-hierarchy` (LSP path with outgoing depth measurement), and retains all original testability assessment content as fallback
+
+---
+
+## Behavior 8: qc-planner output format includes signaling note
+
+**Given** the Output Format section (the plan template in Step 5) has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line from the skill
+
+- [x] **RED**: Verify the plan template in Step 5 has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the plan output template
+  - In the plan template inside Step 5, add a line in the Analysis Summary section or just above it: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: The plan template contains the signaling line with both options indicated
+
+---
+
+## Edge Cases (Low Risk)
+
+### Fallback consistency check -- review-tests
+- [x] **VERIFY**: Step 5 of review-tests has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in review-tests.md -- expect at least one match in Step 5
+
+### Fallback consistency check -- qc-planner
+- [x] **VERIFY**: Step 3 of qc-planner has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in qc-planner.md -- expect at least one match in Step 3
+
+### No changes to unrelated steps -- review-tests
+- [x] **VERIFY**: Steps 1-4 and Step 6 of review-tests are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### No changes to unrelated steps -- qc-planner
+- [x] **VERIFY**: Steps 1, 2, 4, 5 of qc-planner are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### Rules sections unchanged
+- [x] **VERIFY**: Rules section of review-tests still contains all original rules (read-only, no sub-agents, etc.)
+- [x] **VERIFY**: Rules section of qc-planner still contains all original rules (no sub-agents, cap at 5-10, fixed format, etc.)
+
+---
+
+## Final Check
+
+- [x] **Read the full file**: `bee/agents/review-tests.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Glob, Grep + find-references + document-symbols
+- [x] **Skills**: references both tdd-practices and lsp-analysis skills
+- [x] **Steps 1-4**: unchanged
+- [x] **Step 5**: availability check + find-references for coverage gap detection + qualitative fallback
+- [x] **Step 6**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+- [x] **Rules**: unchanged
+
+- [x] **Read the full file**: `bee/agents/qc-planner.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Write, Glob, Grep + call-hierarchy + document-symbols
+- [x] **Skills**: references tdd-practices, clean-code, and lsp-analysis skills
+- [x] **Steps 1-2**: unchanged
+- [x] **Step 3**: availability check + call-hierarchy outgoing for testability depth + original assessment as fallback
+- [x] **Steps 4-5**: unchanged (except signaling line in the plan template)
+- [x] **Output Format**: signaling line added to plan template
+- [x] **Rules**: unchanged
+
+## Verification Summary
+| Category | # Checks | Status |
+|----------|----------|--------|
+| Core behaviors (1-8) | 8 | ✅ |
+| Edge cases | 6 | ✅ |
+| Final check | 16 | ✅ |
+| **Total** | **30** | ✅ |
+
+[x] Reviewed

--- a/docs/specs/lsp-slice-3-tdd-plan.md
+++ b/docs/specs/lsp-slice-3-tdd-plan.md
@@ -1,0 +1,238 @@
+# TDD Plan: LSP-Enhanced context-gatherer + domain-language-extractor -- Slice 3
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/lsp-integration-spec.md`, Slice 3
+- **Slice**: context-gatherer and domain-language-extractor get LSP-enhanced analysis
+- **Risk**: LOW
+- **Nature**: Markdown-only edits to two existing agent files. No runtime code.
+- **Acceptance Criteria**:
+  1. `context-gatherer.md` references the skill in its Skills section
+  2. context-gatherer uses document-symbols and workspace-symbols for language-aware module detection instead of relying solely on folder names
+  3. `domain-language-extractor.md` references the skill in its Skills section
+  4. domain-language-extractor Step 3 (Infer Vocabulary from Code): uses hover for type definitions and document-symbols for interface/type names
+  5. Both agents retain grep-based fallback for each LSP-enhanced step
+  6. Both agents include the signaling note in output
+
+## Codebase Analysis
+
+### File Structure
+- Implementation: `bee/agents/context-gatherer.md` and `bee/agents/domain-language-extractor.md`
+- Skill reference: `bee/skills/lsp-analysis/SKILL.md` (already exists from Slice 0)
+- Pattern reference: `bee/agents/review-coupling.md` (Slice 1), `bee/agents/review-tests.md` and `bee/agents/qc-planner.md` (Slice 2) -- already updated with LSP
+- No runtime tests -- all deliverables are markdown agent files
+
+### Verification Method
+Since this is a markdown-only change, each "test" is a structural verification: grep or read the file and confirm the expected content exists. The RED phase describes what to look for that does NOT yet exist. The GREEN phase adds it. The verification confirms it.
+
+### Current File Structure (context-gatherer.md)
+- Frontmatter: `tools: Read, Glob, Grep`
+- No formal Skills section -- inline instruction on line 12 references clean-code and architecture-patterns skills
+- Process: Sections 1-8 (Project Structure, Architecture Pattern, Test Framework, Project Conventions, Change Area, Existing Documentation, Tidy Opportunities, Design System Signals)
+- Output Format: markdown template with Context Summary subsections
+- No Rules section
+
+### Current File Structure (domain-language-extractor.md)
+- Frontmatter: `tools: Read, Glob, Grep, WebFetch`
+- Skills section: references `skills/architecture-patterns/SKILL.md` and `skills/clean-code/SKILL.md`
+- Process: Steps 1-4 (Extract from Documentation, Extract from Website, Infer from Code, Compare Against Code)
+- Output Format: markdown template with Domain Language Analysis subsections
+- Rules: read-only, no sub-agents, AskUserQuestion sparingly, always produce output, record sources, lead with healthy boundaries
+
+---
+
+## Behavior 1: Create formal Skills section in context-gatherer and add all skill references
+
+**Given** context-gatherer has no formal Skills section, just an inline instruction referencing clean-code and architecture-patterns
+**When** the agent file is updated
+**Then** a formal Skills section exists referencing clean-code, architecture-patterns, AND lsp-analysis, and the inline instruction is replaced
+
+- [x] **RED**: Verify `bee/agents/context-gatherer.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+  - Also note: the inline skill reference on line 12 is not in a formal `## Skills` section
+
+- [x] **GREEN**: Replace the inline instruction with a formal Skills section
+  - Remove the inline instruction line: "Read the `clean-code` skill at `skills/clean-code/SKILL.md` and the `architecture-patterns` skill at `skills/architecture-patterns/SKILL.md` -- these inform what you look for during analysis."
+  - Add a `## Skills` section after the opening paragraph ("You are a codebase analyst...") with three bullets:
+    - `skills/clean-code/SKILL.md` -- clean code principles, naming, SRP
+    - `skills/architecture-patterns/SKILL.md` -- architecture pattern recognition
+    - `skills/lsp-analysis/SKILL.md` -- LSP-enhanced analysis, availability checking, graceful degradation
+  - Keep the instruction to read them: "Before starting, read these skill files for reference:"
+
+- [x] **VERIFY**: Grep for `## Skills` in the file -- expect one match. Grep for `lsp-analysis/SKILL.md` -- expect one match. Grep for the old inline instruction text -- expect zero matches.
+
+---
+
+## Behavior 2: LSP tools added to context-gatherer frontmatter
+
+**Given** the context-gatherer frontmatter has `tools: Read, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Glob, Grep, mcp__lsp__document-symbols, mcp__lsp__workspace-symbols`
+  - Only the tools context-gatherer actually uses: document-symbols (for structural scan + availability check) and workspace-symbols (for architecture marker search)
+
+- [x] **VERIFY**: The `tools:` line contains Read, Glob, Grep and the two LSP tools
+
+---
+
+## Behavior 3: context-gatherer Section 2 gets LSP-first path for architecture detection
+
+**Given** Section 2 (Architecture Pattern) currently only looks for evidence via folder names
+**When** the agent file is updated
+**Then** Section 2 first performs the availability check, then uses document-symbols and workspace-symbols for language-aware module detection, with the original folder-name approach as fallback
+
+- [x] **RED**: Verify Section 2 has no mention of LSP, `document-symbols`, or `workspace-symbols`
+
+- [x] **GREEN**: Rewrite Section 2 to add LSP-first path
+  - Add availability check at the top of Section 2: attempt `document-symbols` on one source file; if it returns symbols, LSP is available for this section. Decide once; do not retry if it fails.
+  - Add LSP path: use `document-symbols` on key source files to find classes, interfaces, and types that reveal architecture (e.g., finding a class named `OrderController` or an interface named `OrderPort` is stronger evidence than a folder named `controllers/`). Use `workspace-symbols` to search for architectural markers: Controller, Service, Repository, Port, Adapter, Handler, UseCase, Gateway, etc. This detects architecture from actual code structure, not just folder conventions.
+  - Keep the existing folder-name evidence list as the explicit fallback under a "Fallback (LSP unavailable)" sub-section -- the full list of directory patterns (domain/, ports/, controllers/, events/, commands/, etc.)
+  - Preserve the opening instruction and the "Describe what you actually found" guidance
+
+- [x] **VERIFY**: Section 2 contains `document-symbols` (availability check + structural scan), `workspace-symbols` (architecture marker search), and retains the full folder-name evidence list as fallback
+
+---
+
+## Behavior 4: context-gatherer output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line from the skill
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line after `## Context Summary` and before `### Project Structure`: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Behavior 5: Skill reference added to domain-language-extractor Skills section
+
+**Given** the domain-language-extractor Skills section references architecture-patterns and clean-code
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/domain-language-extractor.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a third bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced analysis, availability checking, graceful degradation`
+  - Keep the existing architecture-patterns and clean-code skill references unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 6: LSP tools added to domain-language-extractor frontmatter
+
+**Given** the domain-language-extractor frontmatter has `tools: Read, Glob, Grep, WebFetch`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Glob, Grep, WebFetch, mcp__lsp__document-symbols, mcp__lsp__hover`
+  - Keep WebFetch (domain-language-extractor needs it for website analysis)
+  - Only the tools this agent actually uses: document-symbols (for interface/type names + availability check) and hover (for type definitions)
+
+- [x] **VERIFY**: The `tools:` line contains Read, Glob, Grep, WebFetch and the two LSP tools
+
+---
+
+## Behavior 7: domain-language-extractor Step 3 gets LSP-first path for vocabulary extraction
+
+**Given** Step 3 (Infer Vocabulary from Code) currently uses Glob for directory names and Grep for class/module/function declarations
+**When** the agent file is updated
+**Then** Step 3 first performs the availability check, then uses document-symbols for interface/type names and hover for type definitions, with the original approach as fallback
+
+- [x] **RED**: Verify Step 3 has no mention of LSP, `document-symbols`, or `hover`
+
+- [x] **GREEN**: Rewrite Step 3 to add LSP-first path
+  - Add availability check at the top of Step 3: attempt `document-symbols` on one source file; if it returns symbols, LSP is available for this step. Decide once; do not retry if it fails.
+  - Add LSP path: use `document-symbols` on key source files to extract interface names, type aliases, class names, and enum values -- these are domain vocabulary expressed in code. Use `hover` on key symbols to get type definitions, which reveal domain relationships (e.g., hovering over `order.shipment` reveals whether Shipment is its own type or just a string field). This produces richer vocabulary than directory names and grep patterns alone.
+  - Keep the existing approach as the explicit fallback under a "Fallback (LSP unavailable)" sub-section -- the four existing bullets about Glob for directories, reading directory names, Grep for declarations, and looking for naming patterns
+  - Preserve the closing instruction about recording each code-derived concept with its source
+
+- [x] **VERIFY**: Step 3 contains `document-symbols` (availability check + interface/type extraction), `hover` (type definitions), and retains all four original bullets as fallback
+
+---
+
+## Behavior 8: domain-language-extractor output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line from the skill
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line after `## Domain Language Analysis` and before `### Domain Vocabulary`: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Edge Cases (Low Risk)
+
+### Fallback consistency check -- context-gatherer
+- [x] **VERIFY**: Section 2 of context-gatherer has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in context-gatherer.md -- expect at least one match in Section 2
+
+### Fallback consistency check -- domain-language-extractor
+- [x] **VERIFY**: Step 3 of domain-language-extractor has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in domain-language-extractor.md -- expect at least one match in Step 3
+
+### No changes to unrelated sections -- context-gatherer
+- [x] **VERIFY**: Sections 1, 3-8 of context-gatherer are unchanged
+  - These sections have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### No changes to unrelated steps -- domain-language-extractor
+- [x] **VERIFY**: Steps 1, 2, 4 of domain-language-extractor are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### Rules section unchanged -- domain-language-extractor
+- [x] **VERIFY**: Rules section of domain-language-extractor still contains all original rules (read-only, no sub-agents, AskUserQuestion sparingly, always produce output, record sources, lead with healthy boundaries)
+
+---
+
+## Final Check
+
+- [x] **Read the full file**: `bee/agents/context-gatherer.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Glob, Grep + document-symbols + workspace-symbols
+- [x] **Skills**: formal section referencing clean-code, architecture-patterns, and lsp-analysis
+- [x] **Inline instruction removed**: the old inline skill reference line is gone
+- [x] **Section 1**: unchanged
+- [x] **Section 2**: availability check + document-symbols for structural scan + workspace-symbols for architecture markers + folder-name fallback
+- [x] **Sections 3-8**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+
+- [x] **Read the full file**: `bee/agents/domain-language-extractor.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Glob, Grep, WebFetch + document-symbols + hover
+- [x] **Skills**: references architecture-patterns, clean-code, and lsp-analysis
+- [x] **Steps 1-2**: unchanged
+- [x] **Step 3**: availability check + document-symbols for interface/type names + hover for type definitions + original approach as fallback
+- [x] **Step 4**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+- [x] **Rules**: unchanged
+
+## Verification Summary
+| Category | # Checks | Status |
+|----------|----------|--------|
+| Core behaviors (1-8) | 8 | ✅ |
+| Edge cases | 5 | ✅ |
+| Final check | 16 | ✅ |
+| **Total** | **29** | ✅ |
+
+[x] Reviewed

--- a/docs/specs/lsp-slice-4-5-tdd-plan.md
+++ b/docs/specs/lsp-slice-4-5-tdd-plan.md
@@ -1,0 +1,260 @@
+# TDD Plan: LSP-Enhanced architecture-test-writer + review-code-quality -- Slices 4 and 5
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: User-provided spec for Slices 4 and 5
+- **Slice 4**: architecture-test-writer gets LSP-enhanced analysis
+- **Slice 5**: review-code-quality gets LSP-enhanced analysis
+- **Risk**: LOW
+- **Nature**: Markdown-only edits to two existing agent files. No runtime code.
+- **Acceptance Criteria**:
+  1. `architecture-test-writer.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+  2. architecture-test-writer Steps 3-4 (Generate Passing/Failing Tests): uses find-references to validate boundary assertions with real dependency data instead of grep for import statements
+  3. `review-code-quality.md` references `skills/lsp-analysis/SKILL.md` in its Skills section
+  4. review-code-quality Step 2 (Review Each File): uses hover for type information when assessing complexity, and LSP diagnostics for compiler-level warnings
+  5. Both agents retain grep-based fallback for each LSP-enhanced step
+  6. Both agents include the signaling note in output
+
+## Codebase Analysis
+
+### File Structure
+- Implementation: `bee/agents/architecture-test-writer.md` and `bee/agents/review-code-quality.md`
+- Skill reference: `bee/skills/lsp-analysis/SKILL.md` (already exists from Slice 0)
+- Pattern reference: `bee/agents/review-coupling.md` (Slice 1), `bee/agents/review-tests.md` and `bee/agents/qc-planner.md` (Slice 2), `bee/agents/context-gatherer.md` and `bee/agents/domain-language-extractor.md` (Slice 3) -- already updated with LSP
+- No runtime tests -- all deliverables are markdown agent files
+
+### Verification Method
+Since this is a markdown-only change, each "test" is a structural verification: grep or read the file and confirm the expected content exists. The RED phase describes what to look for that does NOT yet exist. The GREEN phase adds it. The verification confirms it.
+
+### Current File Structure (architecture-test-writer.md)
+- Frontmatter: `tools: Read, Write, Glob, Grep`
+- Skills section: references architecture-patterns, clean-code, and tdd-practices
+- Process: Steps 1-5 (Detect Test Framework, Determine Test Output Location, Generate Passing Boundary Tests, Generate Failing Architecture Leak Tests, Write Test Files with Comment Headers)
+- Output Format: markdown template with Files Created + Summary + What This Means
+- Rules: do not modify existing test files, no sub-agents, runnable as-is, one assertion per test
+
+### Current File Structure (review-code-quality.md)
+- Frontmatter: `tools: Read, Glob, Grep`
+- Skills section: references clean-code and architecture-patterns
+- Process: Steps 1-4 (Prioritize Files, Review Each File, Distinguish Active vs Dormant Debt, Categorize)
+- Output Format: markdown template with Working Well + Findings
+- Rules: read-only, no sub-agents, every finding needs a WHY, be specific, don't nitpick stable code
+
+---
+
+## Behavior 1: Skill reference added to architecture-test-writer Skills section
+
+**Given** the architecture-test-writer Skills section references architecture-patterns, clean-code, and tdd-practices
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/architecture-test-writer.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a fourth bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced analysis, availability checking, graceful degradation`
+  - Keep the existing three skill references unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 2: LSP tools added to architecture-test-writer frontmatter
+
+**Given** the architecture-test-writer frontmatter has `tools: Read, Write, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones (preserving Write)
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Write, Glob, Grep, mcp__lsp__find-references, mcp__lsp__document-symbols`
+  - Keep Write (architecture-test-writer needs it to create test files)
+  - Only the tools this agent actually uses: find-references (for boundary validation in Steps 3-4) and document-symbols (for availability check)
+
+- [x] **VERIFY**: The `tools:` line contains Read, Write, Glob, Grep and the two LSP tools
+
+---
+
+## Behavior 3: architecture-test-writer Step 3 gets LSP-first path for passing boundary tests
+
+**Given** Step 3 (Generate Passing Boundary Tests) currently validates boundaries by checking module existence, dependency direction, and concept ownership without LSP
+**When** the agent file is updated
+**Then** Step 3 first performs the availability check, then uses find-references to validate real cross-module dependency data, with the original approach as fallback
+
+- [x] **RED**: Verify Step 3 has no mention of LSP, `document-symbols`, or `find-references`
+
+- [x] **GREEN**: Add LSP-first path to Step 3
+  - Add availability check at the top of Step 3: attempt `document-symbols` on one source file; if it returns symbols, LSP is available for this step. Decide once; do not retry if it fails.
+  - Add LSP path: use `find-references` on key module exports to discover actual cross-module dependencies. Instead of generating tests that grep for import statements, generate tests that assert dependency direction based on real reference data. For example, if `find-references` on an Orders module export shows references only from allowed modules, generate a passing test documenting that boundary.
+  - Keep the existing approach (module existence, dependency direction via imports, concept ownership) as the explicit fallback under a "Fallback (LSP unavailable)" sub-section
+  - Preserve the framework-specific syntax examples and descriptive naming guidance
+
+- [x] **VERIFY**: Step 3 contains `document-symbols` (availability check), `find-references` (real dependency validation), and retains the original approach as fallback
+
+---
+
+## Behavior 4: architecture-test-writer Step 4 gets LSP-first path for failing leak tests
+
+**Given** Step 4 (Generate Failing Architecture Leak Tests) currently asserts desired state based on assessment report mismatches without LSP
+**When** the agent file is updated
+**Then** Step 4 uses find-references to confirm boundary violations with real reference data, with the original approach as fallback
+
+- [x] **RED**: Verify Step 4 has no mention of LSP or `find-references`
+
+- [x] **GREEN**: Add LSP-first path to Step 4
+  - Add LSP path (availability already determined in Step 3 -- reuse that decision): use `find-references` on symbols identified in boundary violations to confirm the actual cross-boundary references exist. This produces more precise failing tests because the test assertions reference real dependency paths rather than inferred ones from the assessment report alone.
+  - Keep the existing approach (vocabulary drift tests, boundary violation tests from report) as the explicit fallback under a "Fallback (LSP unavailable)" sub-section
+  - Preserve the FIXME comment guidance, the explanation comments requirement, and the rule about not using skip/pending markers
+
+- [x] **VERIFY**: Step 4 contains `find-references` (LSP path) and retains the original mismatch-based approach as fallback
+
+---
+
+## Behavior 5: architecture-test-writer output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line after `## Architecture Tests Generated` and before `### Files Created`: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Behavior 6: Skill reference added to review-code-quality Skills section
+
+**Given** the review-code-quality Skills section references clean-code and architecture-patterns
+**When** the agent file is updated
+**Then** the Skills section also references `skills/lsp-analysis/SKILL.md`
+
+- [x] **RED**: Verify `bee/agents/review-code-quality.md` does NOT contain `lsp-analysis/SKILL.md`
+  - Grep for `lsp-analysis` in the file -- expect zero matches
+
+- [x] **GREEN**: Add the skill reference
+  - In the Skills section, add a third bullet: `- \`skills/lsp-analysis/SKILL.md\` -- LSP-enhanced analysis, availability checking, graceful degradation`
+  - Keep the existing clean-code and architecture-patterns skill references unchanged
+
+- [x] **VERIFY**: Grep for `lsp-analysis/SKILL.md` in the file -- expect one match in the Skills section
+
+---
+
+## Behavior 7: LSP tools added to review-code-quality frontmatter
+
+**Given** the review-code-quality frontmatter has `tools: Read, Glob, Grep`
+**When** the agent file is updated
+**Then** the frontmatter includes LSP tools alongside the existing ones
+
+- [x] **RED**: Verify frontmatter `tools:` line does NOT contain any LSP tool names
+
+- [x] **GREEN**: Update the `tools:` line in the frontmatter
+  - Change to: `tools: Read, Glob, Grep, mcp__lsp__hover, mcp__lsp__document-symbols`
+  - Only the tools this agent actually uses: hover (for type-aware complexity assessment) and document-symbols (for availability check)
+
+- [x] **VERIFY**: The `tools:` line contains Read, Glob, Grep and the two LSP tools
+
+---
+
+## Behavior 8: review-code-quality Step 2 gets LSP-first path for type-aware review
+
+**Given** Step 2 (Review Each File) currently checks against clean code principles using only text-based reading
+**When** the agent file is updated
+**Then** Step 2 first performs the availability check, then uses hover for type information and document-symbols for structural overview, with the original approach as fallback
+
+- [x] **RED**: Verify Step 2 has no mention of LSP, `document-symbols`, or `hover`
+
+- [x] **GREEN**: Add LSP-first path to Step 2
+  - Add availability check at the top of Step 2: attempt `document-symbols` on one source file in scope; if it returns symbols, LSP is available for this step. Decide once; do not retry if it fails.
+  - Add LSP path: use `hover` on function signatures and key variables to get type information for more precise complexity assessment -- e.g., a function returning `Promise<Result<Order, ValidationError>>` reveals more about SRP than reading the function body alone. Use `hover` on imports to understand actual dependency types (interface vs concrete class) for dependency direction analysis. LSP diagnostics (compiler warnings, unused variables, type errors) supplement the manual checks.
+  - Keep the existing seven review criteria (SRP, DRY, YAGNI, Naming, Small functions, Error handling, Dependency direction) as the explicit fallback under a "Fallback (LSP unavailable)" sub-section -- all seven bullet points preserved exactly
+  - Preserve the opening instruction about checking against clean code principles
+
+- [x] **VERIFY**: Step 2 contains `document-symbols` (availability check), `hover` (type-aware assessment), and retains all seven original review criteria as fallback
+
+---
+
+## Behavior 9: review-code-quality output format includes signaling note
+
+**Given** the Output Format section has no mention of analysis method signaling
+**When** the agent file is updated
+**Then** the output template includes the signaling line
+
+- [x] **RED**: Verify Output Format section has no mention of "Analysis method"
+
+- [x] **GREEN**: Add signaling to the Output Format template
+  - Add a line after `## Code Quality Review` and before `### Working Well`: `Analysis method: [LSP-enhanced analysis | text-based pattern matching]`
+
+- [x] **VERIFY**: Output Format contains the signaling line with both options indicated
+
+---
+
+## Edge Cases (Low Risk)
+
+### Fallback consistency check -- architecture-test-writer Step 3
+- [x] **VERIFY**: Step 3 of architecture-test-writer has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in architecture-test-writer.md -- expect at least one match in Step 3
+
+### Fallback consistency check -- architecture-test-writer Step 4
+- [x] **VERIFY**: Step 4 of architecture-test-writer has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in architecture-test-writer.md -- expect at least one match in Step 4
+
+### Fallback consistency check -- review-code-quality
+- [x] **VERIFY**: Step 2 of review-code-quality has explicit fallback language
+  - Grep for "fallback" or "LSP unavailable" or "LSP is not available" in review-code-quality.md -- expect at least one match in Step 2
+
+### No changes to unrelated steps -- architecture-test-writer
+- [x] **VERIFY**: Steps 1, 2, 5 of architecture-test-writer are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### No changes to unrelated steps -- review-code-quality
+- [x] **VERIFY**: Steps 1, 3, 4 of review-code-quality are unchanged
+  - These steps have no LSP enhancement in the spec -- confirm they remain as-is by reading the file
+
+### Rules sections unchanged
+- [x] **VERIFY**: Rules section of architecture-test-writer still contains all original rules (do not modify existing test files, no sub-agents, runnable as-is, one assertion per test, etc.)
+- [x] **VERIFY**: Rules section of review-code-quality still contains all original rules (read-only, no sub-agents, every finding needs a WHY, be specific, don't nitpick stable code)
+
+### Write tool preserved in architecture-test-writer
+- [x] **VERIFY**: The frontmatter `tools:` line in architecture-test-writer still includes `Write` -- this agent creates test files and must retain write capability
+
+---
+
+## Final Check
+
+- [x] **Read the full file**: `bee/agents/architecture-test-writer.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Write, Glob, Grep + find-references + document-symbols
+- [x] **Skills**: references architecture-patterns, clean-code, tdd-practices, and lsp-analysis
+- [x] **Steps 1-2**: unchanged
+- [x] **Step 3**: availability check + find-references for real dependency validation + original approach as fallback
+- [x] **Step 4**: find-references for confirming boundary violations + original mismatch approach as fallback
+- [x] **Step 5**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+- [x] **Rules**: unchanged
+
+- [x] **Read the full file**: `bee/agents/review-code-quality.md` top to bottom
+- [x] **Frontmatter**: tools line includes Read, Glob, Grep + hover + document-symbols
+- [x] **Skills**: references clean-code, architecture-patterns, and lsp-analysis
+- [x] **Step 1**: unchanged
+- [x] **Step 2**: availability check + hover for type-aware complexity + all seven review criteria preserved as fallback
+- [x] **Steps 3-4**: unchanged
+- [x] **Output Format**: signaling line added, structure preserved
+- [x] **Rules**: unchanged
+
+## Verification Summary
+| Category | # Checks | Status |
+|----------|----------|--------|
+| Core behaviors (1-9) | 9 | ✅ |
+| Edge cases | 8 | ✅ |
+| Final check | 17 | ✅ |
+| **Total** | **34** | ✅ |
+
+[x] Reviewed


### PR DESCRIPTION
## Summary

- Add shared `lsp-analysis` skill teaching Bee agents to use Claude Code's built-in LSP operations (find-references, call-hierarchy, hover, document-symbols, workspace-symbols) for precise dependency graphs
- Integrate LSP-first analysis with graceful grep fallback into all 7 code-analysis agents: review-coupling, review-tests, qc-planner, context-gatherer, domain-language-extractor, architecture-test-writer, review-code-quality
- Each agent gets only the LSP tools it needs, checks availability once, and falls back transparently — output signals which method was used

## Test plan

- [ ] Verify `bee/skills/lsp-analysis/SKILL.md` documents all 6 LSP operations, graph reasoning, availability check, graceful degradation, and per-language server reference
- [ ] Verify each of the 7 agents has: skill reference in Skills section, LSP tools in frontmatter, LSP-first path with availability check, explicit grep fallback, signaling line in output format
- [ ] Verify unchanged sections/steps/rules in each agent are preserved
- [ ] Run a Bee workflow on a TypeScript project to confirm LSP-enhanced analysis activates when a language server is available
- [ ] Run a Bee workflow on a project without LSP to confirm graceful fallback to text-based matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)