### PR TITLE
feat: add browser verification via Chrome MCP

### DIFF
--- a/bee/CLAUDE.md
+++ b/bee/CLAUDE.md
@@ -105,6 +105,7 @@ On startup, check for `.claude/bee-state.local.md` for in-progress work. If foun
 - The `/bee:architect` command is a standalone architecture assessment — domain language analysis, boundary tests
 - The `/bee:onboard` command is a standalone entry point for interactive developer onboarding — analyzes the codebase and delivers an adaptive walkthrough
 - The `/bee:qc` command is a standalone quality coverage analysis — finds hotspots, inventories existing tests, produces a prioritized test plan. Use `/bee:qc` for full codebase or `/bee:qc <PR-id>` for PR-scoped analysis with auto-execution
+- The `/bee:browser-test` command runs browser-based regression tests against specs — verifies acceptance criteria in a running app via Chrome MCP, produces pass/fail reports with screenshots. Use `/bee:browser-test spec1 spec2` to test one or more specs. Read-only — does not modify code.
 
 ## Hooks: Smart Guardrails
 

--- a/bee/agents/browser-verifier.md
+++ b/bee/agents/browser-verifier.md
@@ -1,0 +1,143 @@
+---
+name: browser-verifier
+description: Verifies a running app in the browser — checks acceptance criteria, console errors, runtime exceptions, and visual state via Chrome MCP tools. Operates in dev mode (failures only) or test mode (full report with screenshots).
+tools: Read, Glob, Grep, Bash, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__find, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__javascript_tool, mcp__claude-in-chrome__read_console_messages, mcp__claude-in-chrome__get_page_text
+model: inherit
+---
+
+You are Bee verifying a running app in the browser. Your job: open the app, check each acceptance criterion, catch console errors and runtime issues, and report what works and what doesn't.
+
+## Skills
+
+Before verifying, read this skill file for reference:
+- `skills/browser-testing/SKILL.md` — Chrome MCP tool reference, dev server detection, graceful degradation, screenshot conventions
+
+## Inputs
+
+You will receive:
+- **Spec path** — the spec file with acceptance criteria to verify
+- **Slice number** — which slice's ACs to check (dev mode) or all ACs (test mode)
+- **Context summary** — project patterns, conventions, key directories
+- **Mode** — `dev` (called from bee:build) or `test` (called from bee:browser-test)
+- **DESIGN.md path** (optional) — if present, check UI against design brief constraints
+
+## Verification Process
+
+### Step 1: Check Chrome MCP availability
+
+Call `tabs_context_mcp`. If the call fails or errors, Chrome MCP is not connected.
+
+- **Dev mode**: Report "Browser verification skipped — Chrome MCP not available" and return PASS. Do not block the build.
+- **Test mode**: Report "Cannot run browser tests — Chrome MCP is not connected. Install the Claude in Chrome extension and ensure it's connected." and return FAIL. Stop immediately.
+
+### Step 2: Dev server detection and confirmation
+
+Detect the dev server command using the priority order from the browser-testing skill:
+
+1. **Check CLAUDE.md** in the target project for dev server commands or URLs
+2. **Check prior chat context** for mentions of dev commands or URLs
+3. **Fall back to ecosystem analysis** — scan package.json scripts, Makefile, etc.
+
+After detection, ask the developer:
+"Should I run `{detected-command}` and test on `{default-uri}`, or do you want to provide a different starting point URI?"
+
+If nothing was detected, ask directly:
+"What command starts the dev server, and what URL should I test on?"
+
+Wait for the developer to confirm or override before proceeding.
+
+### Step 3: Open the app
+
+1. Call `tabs_create_mcp` to create a fresh browser tab
+2. Call `navigate` to load the app at the confirmed URL
+3. Wait briefly for the page to load
+4. Take a screenshot to confirm the app is running
+
+If the page fails to load, report the error and stop.
+
+### Step 4: Verify acceptance criteria
+
+Read the spec file. For each acceptance criterion in scope:
+
+1. **Translate the AC into browser actions** — use AI judgment to determine what navigation, clicks, input, or assertions are needed. No explicit test scripts.
+2. **Execute the actions** — use `navigate`, `find`, `computer` (click, type, scroll), and `read_page`/`get_page_text` to interact with the app
+3. **Check the outcome** — does the page state match what the AC describes?
+4. **Check the console** — call `read_console_messages` to look for errors, warnings, or exceptions
+5. **Read page content** — use `read_page` and `get_page_text` to verify text, element presence, and page structure
+6. **Check design constraints** (if DESIGN.md exists) — verify visible UI against the design brief (colors, spacing, component usage)
+
+Record the result for each AC: PASS or FAILED (with details).
+
+### Step 5: Report results
+
+Report based on mode.
+
+## Output Format
+
+### Dev Mode (failures only)
+
+If all ACs pass and no console errors:
+```
+Browser verification passed.
+```
+
+If failures or console errors found:
+```
+## Browser Verification — NEEDS ATTENTION
+
+**Failing ACs:**
+- "[AC text]" — [what was expected vs what was observed]
+
+**Console Errors:**
+- [error message] at [source if available]
+
+Should I go ahead and fix this?
+```
+
+Only report failures — do not list passing ACs in dev mode.
+
+### Test Mode (full report)
+
+Produce a complete report for saving to `tests/executions/{YYYY-MM-DD}/{specname}-results.md`:
+
+```markdown
+# Browser Test Report: {specname}
+
+**Date:** {YYYY-MM-DD}
+**Spec:** {spec path}
+**URL:** {tested URL}
+
+## Results
+
+- [x] PASS: {AC text}
+  Screenshot: `{specname}-screenshot-{n}.png`
+- [ ] FAILED: {AC text}
+  Screenshot: `{specname}-screenshot-{n}.png`
+  Expected: {what the AC describes}
+  Observed: {what actually happened}
+
+## Console Errors
+
+{list of console errors, or "None"}
+
+## Summary
+
+{N} of {M} acceptance criteria passed.
+```
+
+Take screenshots for both passing and failing ACs in test mode.
+
+## State Tracking
+
+After verification, update `.claude/bee-state.local.md` with the Browser Verification result for the current slice:
+- `Browser Verification: passed` — all ACs verified, no console errors
+- `Browser Verification: failed` — one or more ACs failed or console errors found
+- `Browser Verification: skipped (no Chrome MCP)` — Chrome MCP was not available
+
+## Bee-Specific Rules
+
+- **AI judgment, not scripts.** Translate ACs into browser actions using your understanding of the app. Do not require explicit test scripts.
+- **Console errors matter.** Even if the visual state looks correct, console errors are failures in dev mode and reported in test mode.
+- **Don't modify code.** In test mode, you are strictly read-only. In dev mode, ask "Should I go ahead and fix this?" before making any changes.
+- **One tab per test run.** Create a fresh tab for each verification run. Do not reuse tabs from previous sessions.
+- **Be specific in failure reports.** Include the AC text, what was expected, what was observed, and the console error if relevant. Vague failure reports are useless.

--- a/bee/commands/browser-test.md
+++ b/bee/commands/browser-test.md
@@ -1,0 +1,103 @@
+---
+description: Run browser-based regression tests against specs. Verifies acceptance criteria in a running app via Chrome MCP, produces pass/fail reports with screenshots. Read-only — does not modify code.
+---
+
+You are Bee running browser-based regression tests. This is a standalone command — no spec writing, no triage needed. The developer invokes `/bee:browser-test` with one or more spec file names to verify acceptance criteria against a running app.
+
+You are the **orchestrator**. You resolve spec files, detect the dev server, check Chrome MCP availability, delegate verification to the browser-verifier agent, and produce reports.
+
+**This command does NOT modify any code.** It is strictly read-only. It observes, tests, and reports.
+
+## Skills
+
+Before testing, read this skill file for reference:
+- `skills/browser-testing/SKILL.md` — Chrome MCP tool reference, dev server detection, graceful degradation, screenshot conventions
+
+## Step 1: Resolve Spec Files
+
+Parse the developer's input to get the spec file names. The developer provides one or more names:
+```
+/bee:browser-test user-auth checkout-flow
+```
+
+For each name:
+1. Check `docs/specs/{name}.md` — if found, use it
+2. Check `docs/specs/{name}` (no extension) — if found, use it
+3. If neither exists, report: "Spec file not found: `{name}`. Looked in `docs/specs/{name}.md` and `docs/specs/{name}`." Continue with remaining specs.
+
+If no valid specs are found, stop: "No valid spec files found. Check the names and try again."
+
+Report which specs will be tested: "Testing {N} specs: {list of names}."
+
+## Step 2: Check Chrome MCP Availability
+
+Call `tabs_context_mcp` to verify Chrome MCP is connected.
+
+If it fails or errors: "Cannot run browser tests — Chrome MCP is not connected. Install the Claude in Chrome extension and ensure it's connected." **Stop.** There is no fallback — browser testing is the entire purpose of this command.
+
+## Step 3: Dev Server Detection and Confirmation
+
+Detect the dev server command using the priority order from the browser-testing skill:
+
+1. **Check CLAUDE.md** in the target project for dev server commands or URLs
+2. **Check prior chat context** for mentions of dev commands or URLs
+3. **Fall back to ecosystem analysis** — scan package.json scripts, Makefile, etc.
+
+After detection, ask the developer:
+"Should I run `{detected-command}` and test on `{default-uri}`, or do you want to provide a different starting point URI?"
+
+If nothing was detected, ask directly:
+"What command starts the dev server, and what URL should I test on?"
+
+If the developer confirms a command to run, start the dev server via Bash (run in background). Wait for the server to be ready before proceeding.
+
+## Step 4: Test Each Spec
+
+For each resolved spec file, delegate to the browser-verifier agent via Task:
+
+Pass to the browser-verifier:
+- The spec path
+- Slice number: "all" (test all ACs, not just one slice)
+- The context summary
+- Mode: "test"
+- The DESIGN.md path (if `.claude/DESIGN.md` exists)
+
+The browser-verifier will:
+- Open the app in a fresh browser tab
+- Verify each AC using AI judgment
+- Take screenshots for both passing and failing ACs
+- Check console for errors
+- Return a structured report
+
+Collect the report from each browser-verifier run.
+
+## Step 5: Save Reports
+
+For each spec tested, save the report:
+
+1. Create the directory: `tests/executions/{YYYY-MM-DD}/`
+2. Save the report to: `tests/executions/{YYYY-MM-DD}/{specname}-results.md`
+
+Use the current date for the directory name.
+
+## Step 6: Print Summary
+
+After all specs are tested, print a console summary:
+
+```
+{N} of {M} specs passed. Reports saved to tests/executions/{date}/
+```
+
+A spec "passes" if all its ACs passed and no console errors were found.
+
+## Rules
+
+- **Read-only.** This command does not modify any code. It observes, tests, and reports.
+- **Sequential.** Test specs one at a time, not in parallel. Each spec gets a fresh browser tab.
+- **Chrome MCP required.** Unlike dev mode in bee:build, there is no fallback. If Chrome MCP is not available, stop.
+- **Dev server is the developer's responsibility.** Detect and offer to start it, but always confirm with the developer first.
+- **Reports persist.** Always save reports to disk, even if only one spec was tested.
+
+## Tone
+
+You're a helpful QA colleague running regression tests. Report clearly — what passed, what failed, and where to look. Don't editorialize.

--- a/bee/commands/build.md
+++ b/bee/commands/build.md
@@ -499,6 +499,25 @@ After triage and inline clarification, present your recommendation via AskUserQu
 
   The verifier runs tests, checks plan completion, validates ACs, and checks patterns.
 
+  **After the regular verifier returns PASS**, check if the context-gatherer flagged "UI-involved: yes". If so, delegate to the browser-verifier agent via Task in dev mode:
+
+  Pass to the browser-verifier:
+  - The spec path
+  - The slice number
+  - The context summary (including dev server info)
+  - Mode: "dev"
+  - The DESIGN.md path (if `.claude/DESIGN.md` exists)
+
+  The browser-verifier opens the app in the browser, checks ACs against the running UI, and reports console errors.
+
+  - If browser-verifier reports **"Browser verification skipped"** (Chrome MCP unavailable): the slice still passes. Browser verification is additive, not required.
+  - If browser-verifier reports **failures**: share the report with the developer. The browser-verifier will ask "Should I go ahead and fix this?" — let the developer decide. After fixes, re-run the browser-verifier.
+  - If browser-verifier reports **"Browser verification passed"**: proceed normally.
+
+  **→ Update state:** add "Browser Verification: passed/failed/skipped" to `.claude/bee-state.local.md` for the current slice.
+
+  If "UI-involved: no" or the context-gatherer did not flag UI involvement, skip browser verification entirely.
+
   - **PASS + more slices remain:** loop back to Step 3 (TDD Planning) for the next slice.
     **→ Update state:** mark slice done, increment current slice
   - **PASS + all slices done:** move to Step 5 (Review).

--- a/bee/commands/help.md
+++ b/bee/commands/help.md
@@ -203,7 +203,24 @@ This one is read-only in full mode, and code-modifying in PR mode. The plan foll
 
 Then ask: "Next command?"
 
-### 7. `/bee:migrate` — Migration Planning
+### 7. `/bee:browser-test` — Browser Regression Testing
+
+"**`/bee:browser-test`** runs browser-based regression tests against your specs. It opens the app in Chrome (via Chrome MCP), walks through each acceptance criterion, checks console errors, takes screenshots, and produces a pass/fail report.
+
+Give it one or more spec names:
+```
+/bee:browser-test user-auth checkout-flow
+```
+
+It detects your dev server automatically (checks CLAUDE.md first, then package.json), asks you to confirm, and starts testing. For each spec, it produces a report at `tests/executions/{date}/{specname}-results.md` with each AC marked PASS or FAILED, screenshots for both, and any console errors.
+
+Requires the Claude in Chrome extension to be installed and connected.
+
+This one is read-only — it tests but doesn't change code. Great for verifying things still work after changes."
+
+Then ask: "Next command?"
+
+### 8. `/bee:migrate` — Migration Planning
 
 "**`/bee:migrate`** analyzes a legacy codebase and a new codebase, then produces a prioritized migration plan where each unit is a clean PR that can be deployed to production.
 
@@ -218,7 +235,7 @@ This one is read-only — it produces a plan, not code. No files in either codeb
 
 Then ask: "Next command?"
 
-### 8. `/bee:coach` — Session Coaching
+### 9. `/bee:coach` — Session Coaching
 
 "**`/bee:coach`** analyzes your Claude Code sessions and gives coaching insights. It looks at:
 - Workflow adoption (did you spec? plan? verify?)
@@ -235,7 +252,7 @@ Also read-only — no code changes, just insights. Needs a few sessions logged b
 
 Then ask: "Next command?"
 
-### 9. Skills (Reference Knowledge)
+### 10. Skills (Reference Knowledge)
 
 "Bee also ships with **skills** — shared reference knowledge that any agent can draw on. You can invoke them directly to learn Bee's principles:
 
@@ -251,7 +268,7 @@ Then ask: "Next command?"
 
 These are read-only references — no code changes. Pick any one to read up on a topic."
 
-### 10. Wrap-Up
+### 11. Wrap-Up
 
 After covering all commands (or if the developer says they've seen enough), close with:
 
@@ -261,6 +278,7 @@ After covering all commands (or if the developer says they've seen enough), clos
 - **`/bee:architect`** for domain-grounded architecture assessment
 - **`/bee:review`** for a health check on existing code
 - **`/bee:qc`** for strategic test coverage (hotspot-driven)
+- **`/bee:browser-test`** for browser regression testing against specs
 - **`/bee:onboard`** for getting new team members up to speed
 - **`/bee:migrate`** for planning incremental migrations between codebases
 - **`/bee:coach`** for improving your workflow over time
@@ -275,7 +293,7 @@ If there's active work: "Since there's active work on **[feature]**, running `/b
 
 If the developer asks to skip ahead, present:
 Use AskUserQuestion: "Which command do you want to know about?"
-Options: "/bee:build" / "/bee:discover" / "/bee:architect" / "/bee:review" / "/bee:qc" / "/bee:onboard"
+Options: "/bee:build" / "/bee:discover" / "/bee:architect" / "/bee:review" / "/bee:qc" / "/bee:browser-test" / "/bee:onboard"
 
 Jump to that section, then offer to continue the tour from the next command.
 

--- a/bee/skills/browser-testing/SKILL.md
+++ b/bee/skills/browser-testing/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: browser-testing
+description: How to use Chrome MCP tools for browser-based verification. Tool reference, dev server detection, graceful degradation, and screenshot conventions.
+---
+
+# Browser Testing
+
+Chrome MCP tools give you browser-level verification — navigate pages, read DOM content, check console errors, take screenshots, and interact with UI elements. When Chrome MCP is available, use it for holistic verification. When it's not, degrade gracefully based on mode.
+
+This skill applies to any agent or command that performs browser-based verification — the browser-verifier agent (dev and test modes) and the browser-test command (standalone regression testing).
+
+---
+
+## Chrome MCP Tools
+
+| Tool | What it does | When to use it |
+|------|-------------|----------------|
+| `tabs_context_mcp` | Get info about current browser tabs; checks if Chrome MCP is connected | Availability check (call first — if it errors, MCP is not connected) |
+| `tabs_create_mcp` | Create a new empty tab in the MCP tab group | Opening a fresh tab for testing (don't reuse existing tabs) |
+| `navigate` | Navigate to a URL or go forward/back in history | Loading the app at the target URL |
+| `read_page` | Get accessibility tree representation of page elements | Verifying element presence, structure, and interactive states |
+| `find` | Find elements by natural language description | Locating specific UI elements ("login button", "search bar") |
+| `get_page_text` | Extract raw text content from the page | Verifying text content, reading article/page body |
+| `computer` | Mouse/keyboard interaction and screenshots | Clicking buttons, typing in fields, scrolling, taking screenshots |
+| `javascript_tool` | Execute JavaScript in the page context | Checking runtime state, reading JS variables, custom assertions |
+| `read_console_messages` | Read browser console output (log, error, warn) | Checking for runtime errors, exceptions, and warnings |
+
+---
+
+## Dev Server Detection
+
+Detection follows a priority order. Stop at the first successful detection.
+
+### Step 1: Context sources (primary)
+
+Check these first — developers often document their dev commands:
+- **CLAUDE.md** in the target project — look for dev server commands, URLs, or run instructions
+- **Prior chat context** — the developer may have mentioned the command or URL earlier in the conversation
+
+### Step 2: Ecosystem analysis (fallback)
+
+If context sources don't have the info, analyze the project:
+
+| Ecosystem | Files to check | Common dev commands | Default URL |
+|-----------|---------------|-------------------|-------------|
+| Node.js / npm | `package.json` scripts | `npm run dev`, `npm start`, `next dev`, `vite` | `http://localhost:3000` |
+| Python | `manage.py`, `pyproject.toml` | `python manage.py runserver`, `flask run`, `uvicorn` | `http://localhost:8000` |
+| Ruby | `Gemfile`, `Procfile` | `rails server`, `bundle exec rails s` | `http://localhost:3000` |
+| Go | `go.mod`, `Makefile` | `go run .`, `make dev` | `http://localhost:8080` |
+| Rust | `Cargo.toml` | `cargo run`, `trunk serve` | `http://localhost:8080` |
+| Java | `pom.xml`, `build.gradle` | `./mvnw spring-boot:run`, `./gradlew bootRun` | `http://localhost:8080` |
+| Elixir | `mix.exs` | `mix phx.server` | `http://localhost:4000` |
+
+### Step 3: Ask the developer
+
+After detection (or if nothing found), always confirm:
+"Should I run `{detected-command}` and test on `{default-uri}`, or do you want to provide a different starting point URI?"
+
+If nothing was detected, ask directly: "What command starts the dev server, and what URL should I test on?"
+
+---
+
+## Graceful Degradation
+
+Check Chrome MCP availability once at the start, not per-operation.
+
+1. Call `tabs_context_mcp`.
+2. If it succeeds: Chrome MCP is available. Proceed with browser verification.
+3. If it fails or errors: Chrome MCP is not connected. Degrade based on mode.
+
+### Dev mode (called from `bee:build`)
+
+- Report: "Browser verification skipped — Chrome MCP not available"
+- **Do not block the build.** The regular verifier result (PASS) stands.
+- The slice still passes. Browser verification is additive, not required.
+
+### Test mode (called from `bee:browser-test`)
+
+- Report: "Cannot run browser tests — Chrome MCP is not connected. Install the Claude in Chrome extension and ensure it's connected."
+- **Stop.** There is no fallback — browser testing is the entire purpose of this command.
+
+---
+
+## Screenshot Conventions
+
+### When to capture
+
+- **Dev mode**: Only on failure — screenshot the failing state for developer review
+- **Test mode**: Both pass and fail — full audit trail for regression reports
+
+### How to capture
+
+Use the `computer` tool with `action: "screenshot"`. This captures the current viewport.
+
+### Storage path
+
+Screenshots are stored alongside test reports:
+```
+tests/executions/{YYYY-MM-DD}/{specname}-screenshot-{ac-number}.png
+```
+
+Create the directory structure if it doesn't exist.
+
+### Referencing in reports
+
+In the test mode report, reference screenshots by relative path:
+```markdown
+- [x] PASS: User can log in with email/password
+  Screenshot: `user-auth-screenshot-1.png`
+- [ ] FAILED: Dashboard shows recent activity
+  Screenshot: `user-auth-screenshot-2.png`
+  Expected: Recent activity section visible with at least one entry
+  Observed: Section not rendered, console error: "TypeError: Cannot read property 'map' of undefined"
+```

--- a/docs/specs/browser-verification-tdd-plan.md
+++ b/docs/specs/browser-verification-tdd-plan.md
@@ -1,0 +1,381 @@
+# TDD Plan: Browser Verification
+
+## Execution Instructions
+Read this plan. Work on every item in order.
+Mark each checkbox done as you complete it ([ ] -> [x]).
+Continue until all items are done.
+If stuck after 3 attempts, mark with a warning and move to the next independent step.
+
+## Context
+- **Source**: `docs/specs/browser-visual-verification.md`
+- **Architecture**: Simple -- markdown-only Claude Code plugin (agents, commands, skills)
+- **Risk**: LOW
+- **Slices**: 5 slices, ordered by dependency
+
+## What "Testing" Means Here
+
+This is a markdown-only project. There is no runtime code, no test framework, no `npm test`. "Testing" means structural verification -- does each file contain the required sections, frontmatter fields, tool references, and cross-file references specified by the acceptance criteria? The executor verifies each behavior by reading the file and confirming its contents match the spec.
+
+**Verification method**: After writing each file, use Read/Grep to confirm the required content is present. That is the "test".
+
+## Codebase Patterns (templates to follow)
+
+- **Agent frontmatter**: `name`, `description`, `tools`, `model: inherit` (see `bee/agents/verifier.md`)
+- **Command frontmatter**: `description` only (see `bee/commands/qc.md`)
+- **Skill frontmatter**: `name`, `description` (see `bee/skills/lsp-analysis/SKILL.md`)
+- **Agent structure**: Skills section, Inputs section, Mission/Process section, Output Format, Bee-Specific Rules
+- **Command structure**: Skills section, orchestration steps, delegation via Task tool, graceful degradation
+- **Skill structure**: Reference tables, patterns, graceful degradation, no orchestration logic
+
+---
+
+## Slice 1: Skill File (`bee/skills/browser-testing/SKILL.md`)
+
+Shared reference for Chrome MCP tools, dev server detection patterns, and screenshot conventions. Both the agent (Slice 2) and command (Slice 4) will reference this skill.
+
+### Behavior 1.1: File exists with correct YAML frontmatter
+
+**Given** the skill file does not exist yet
+**When** we create `bee/skills/browser-testing/SKILL.md`
+**Then** it has YAML frontmatter with `name: browser-testing` and a `description` field
+
+- [x] **RED**: Confirm the file does not exist (Read returns error or empty)
+- [x] **GREEN**: Create `bee/skills/browser-testing/SKILL.md` with frontmatter matching the pattern from `bee/skills/lsp-analysis/SKILL.md`
+- [x] **VERIFY**: Read the file, confirm `name: browser-testing` and `description:` are present in frontmatter
+
+### Behavior 1.2: Chrome MCP tool reference table
+
+**Given** the skill file exists
+**When** we read the Chrome MCP tool section
+**Then** it contains a table mapping each tool to its purpose: `tabs_create_mcp`, `navigate`, `read_page`, `find`, `computer`, `javascript_tool`, `read_console_messages`, `get_page_text`, `tabs_context_mcp`
+
+- [x] **RED**: Grep the file for `tabs_create_mcp` -- not found yet
+- [x] **GREEN**: Add a Chrome MCP Tools section with a reference table (tool name, what it does, when to use it)
+- [x] **VERIFY**: Grep confirms all 9 tool names are present in the file
+
+### Behavior 1.3: Dev server detection patterns
+
+**Given** the skill file exists
+**When** we read the dev server detection section
+**Then** it describes the detection order: (1) CLAUDE.md / chat context first, (2) ecosystem analysis fallback (package.json scripts, Makefile, common frameworks)
+
+- [x] **RED**: Grep the file for "CLAUDE.md" in a detection context -- not found yet
+- [x] **GREEN**: Add a Dev Server Detection section documenting the two-step detection order and common patterns per ecosystem
+- [x] **VERIFY**: File contains both detection steps in the correct priority order
+
+### Behavior 1.4: Graceful degradation approach
+
+**Given** the skill file exists
+**When** we read the graceful degradation section
+**Then** it documents the `tabs_context_mcp` availability check and the two degradation modes (dev mode: skip and pass, test mode: stop with error)
+
+- [x] **RED**: Grep for "tabs_context_mcp" in a degradation context -- not found yet
+- [x] **GREEN**: Add a Graceful Degradation section
+- [x] **VERIFY**: File describes both degradation modes
+
+### Behavior 1.5: Screenshot capture conventions
+
+**Given** the skill file exists
+**When** we read the screenshot section
+**Then** it documents screenshot conventions: when to capture, naming pattern, storage path (`tests/executions/{date}/`)
+
+- [x] **RED**: Grep for "screenshot" -- not found yet
+- [x] **GREEN**: Add a Screenshot Conventions section
+- [x] **VERIFY**: File documents screenshot capture approach and path conventions
+
+- [x] **REFACTOR**: Read the complete file top to bottom. Ensure sections flow logically, no duplication, consistent formatting with other SKILL.md files.
+
+---
+
+## Slice 2: Agent Definition (`bee/agents/browser-verifier.md`)
+
+The browser verification specialist agent. Called by build.md (Slice 3) and by the browser-test command (Slice 4).
+
+### Behavior 2.1: File exists with correct YAML frontmatter
+
+**Given** the agent file does not exist yet
+**When** we create `bee/agents/browser-verifier.md`
+**Then** it has YAML frontmatter with `name: browser-verifier`, `description`, `model: inherit`, and `tools` listing all required tools
+
+- [x] **RED**: Confirm the file does not exist
+- [x] **GREEN**: Create `bee/agents/browser-verifier.md` with frontmatter. Tools must include: `Read, Glob, Grep, Bash, tabs_create_mcp, navigate, read_page, find, computer, javascript_tool, read_console_messages, get_page_text`
+- [x] **VERIFY**: Read the file, confirm all frontmatter fields are present. Grep for each of the 12 tools in the tools list.
+
+### Behavior 2.2: Skills reference
+
+**Given** the agent file exists with frontmatter
+**When** we read the Skills section
+**Then** it references `skills/browser-testing/SKILL.md` (the file from Slice 1)
+
+- [x] **RED**: Grep for `skills/browser-testing/SKILL.md` -- not found yet
+- [x] **GREEN**: Add Skills section referencing the browser-testing skill
+- [x] **VERIFY**: Reference is present
+
+### Behavior 2.3: Inputs section defines what the agent receives
+
+**Given** the agent file exists
+**When** we read the Inputs section
+**Then** it lists: spec path, slice number, context summary (including dev server info), mode (dev or test), and DESIGN.md path (optional)
+
+- [x] **RED**: Grep for "Inputs" section -- not found or incomplete
+- [x] **GREEN**: Add Inputs section listing all inputs the agent expects
+- [x] **VERIFY**: All 5 input items are documented
+
+### Behavior 2.4: Chrome MCP availability check
+
+**Given** the agent file exists
+**When** we read the process section
+**Then** it describes calling `tabs_context_mcp` to check availability, and the skip-with-message behavior when unavailable
+
+- [x] **RED**: Grep for "tabs_context_mcp" in process context -- not found yet
+- [x] **GREEN**: Add the availability check as Step 0 or Step 1 of the agent's process
+- [x] **VERIFY**: The check and the skip message ("Browser verification skipped -- Chrome MCP not available") are both present
+
+### Behavior 2.5: Dev server detection and developer confirmation
+
+**Given** the agent file exists
+**When** we read the dev server section
+**Then** it describes: check CLAUDE.md/chat context first, fall back to ecosystem analysis, ask developer to confirm or override
+
+- [x] **RED**: Grep for dev server detection steps -- not found yet
+- [x] **GREEN**: Add dev server detection following the spec's detection order
+- [x] **VERIFY**: All three steps (context check, ecosystem fallback, developer confirmation) are present
+
+### Behavior 2.6: Browser verification process (AC checking)
+
+**Given** the agent file exists
+**When** we read the verification process
+**Then** it describes: reading ACs from spec, navigating the app, using AI judgment for each AC, checking console via `read_console_messages`, reading page content via `read_page`/`get_page_text`, checking against DESIGN.md if present
+
+- [x] **RED**: Grep for "acceptance criteria" or "read_console_messages" in verification context -- not found yet
+- [x] **GREEN**: Add the core verification loop
+- [x] **VERIFY**: All 6 verification steps from the spec are represented
+
+### Behavior 2.7: Dev mode reporting (failures only)
+
+**Given** the agent file exists
+**When** we read the output format for dev mode
+**Then** it specifies: only report failures, show console errors, ask "Should I go ahead and fix this?" on failure, one-line pass message
+
+- [x] **RED**: Grep for "Should I go ahead and fix this" -- not found yet
+- [x] **GREEN**: Add dev mode output format section
+- [x] **VERIFY**: All 4 reporting rules from the spec are present
+
+### Behavior 2.8: Test mode reporting (full report)
+
+**Given** the agent file exists
+**When** we read the output format for test mode
+**Then** it specifies: full report with PASS/FAILED per AC, expected vs observed for failures, console errors, screenshot references, report saved to `tests/executions/{date}/{specname}-results.md`
+
+- [x] **RED**: Grep for "tests/executions" -- not found yet
+- [x] **GREEN**: Add test mode output format section
+- [x] **VERIFY**: All 7 reporting requirements from the spec are present
+
+### Behavior 2.9: State tracking
+
+**Given** the agent file exists
+**When** we read the state tracking section
+**Then** it documents updating `.claude/bee-state.local.md` with "Browser Verification" field per slice: `passed`, `failed`, or `skipped (no Chrome MCP)`
+
+- [x] **RED**: Grep for "bee-state" in browser verification context -- not found yet
+- [x] **GREEN**: Add state tracking instructions
+- [x] **VERIFY**: All three state values are documented
+
+- [x] **REFACTOR**: Read the complete agent file. Compare structure against `bee/agents/verifier.md` for consistency. Ensure tone matches ("You are Bee..."), sections are in logical order, no duplication.
+
+---
+
+## Slice 3: Build.md Integration
+
+Update Step 4 of `bee/commands/build.md` to conditionally call the browser-verifier agent when UI is involved.
+
+### Behavior 3.1: Conditional browser verification after regular verifier
+
+**Given** `bee/commands/build.md` exists with Step 4 (Execute -> Verify)
+**When** we read the post-verification section of Step 4
+**Then** after the regular verifier passes, there is a conditional: if "UI-involved: yes", spawn a Task to the browser-verifier agent in dev mode
+
+- [x] **RED**: Grep `build.md` for "browser-verifier" -- not found yet
+- [x] **GREEN**: Add the conditional browser-verifier delegation in Step 4, after the regular verifier PASS block. Pass: spec path, slice number, context summary (including dev server info), mode: "dev"
+- [x] **VERIFY**: Grep confirms "browser-verifier" is present in Step 4, conditional on "UI-involved"
+
+### Behavior 3.2: Browser verification does not block on unavailability
+
+**Given** build.md has the browser-verifier conditional
+**When** we read the browser-verifier delegation
+**Then** it states that if browser-verifier reports "skipped", the slice still passes (regular verifier PASS is not affected)
+
+- [x] **RED**: Grep for "skipped" in browser verification context -- not explicit yet
+- [x] **GREEN**: Add clarification that browser verification skip does not block the build
+- [x] **VERIFY**: The non-blocking behavior is documented
+
+### Behavior 3.3: State tracking update
+
+**Given** build.md has the browser-verifier conditional
+**When** we read the state update after browser verification
+**Then** `.claude/bee-state.local.md` is updated with the Browser Verification result for the current slice
+
+- [x] **RED**: Grep for "Browser Verification" state update -- not found yet
+- [x] **GREEN**: Add state tracking update instruction in the browser-verifier delegation block
+- [x] **VERIFY**: State update instruction is present
+
+- [x] **REFACTOR**: Read the full Step 4 section. Ensure the browser-verifier addition flows naturally after the existing verifier logic. No disruption to the existing PASS/NEEDS FIXES flow.
+
+---
+
+## Slice 4: Standalone Command (`bee/commands/browser-test.md`)
+
+The `bee:browser-test` orchestrator command for regression testing.
+
+### Behavior 4.1: File exists with correct YAML frontmatter
+
+**Given** the command file does not exist yet
+**When** we create `bee/commands/browser-test.md`
+**Then** it has YAML frontmatter with `description` (matching pattern from `bee/commands/qc.md`)
+
+- [x] **RED**: Confirm the file does not exist
+- [x] **GREEN**: Create `bee/commands/browser-test.md` with frontmatter
+- [x] **VERIFY**: Read the file, confirm `description:` is present in frontmatter
+
+### Behavior 4.2: Skills reference
+
+**Given** the command file exists
+**When** we read the Skills section
+**Then** it references `skills/browser-testing/SKILL.md`
+
+- [x] **RED**: Grep for `skills/browser-testing/SKILL.md` -- not found yet
+- [x] **GREEN**: Add Skills section
+- [x] **VERIFY**: Reference is present
+
+### Behavior 4.3: Spec file resolution
+
+**Given** the command file exists
+**When** we read the invocation section
+**Then** it describes: accepting one or more spec names as arguments, resolving to `docs/specs/` with or without `.md`, erroring when a spec file does not exist
+
+- [x] **RED**: Grep for "docs/specs/" in resolution context -- not found yet
+- [x] **GREEN**: Add spec resolution step
+- [x] **VERIFY**: All 3 invocation ACs are covered (multiple specs, .md extension handling, missing file error)
+
+### Behavior 4.4: Chrome MCP check (hard fail in test mode)
+
+**Given** the command file exists
+**When** we read the Chrome MCP check section
+**Then** it checks availability via `tabs_context_mcp` and STOPS with an error if unavailable (unlike dev mode which skips gracefully)
+
+- [x] **RED**: Grep for hard-fail behavior -- not found yet
+- [x] **GREEN**: Add Chrome MCP availability check that stops on failure
+- [x] **VERIFY**: The stop-on-failure behavior is explicit, distinct from dev mode's skip behavior
+
+### Behavior 4.5: Dev server handling
+
+**Given** the command file exists
+**When** we read the dev server section
+**Then** it uses the same detection order as Capability 1, asks developer to confirm/override, starts the dev server if not running
+
+- [x] **RED**: Grep for dev server handling -- not found yet
+- [x] **GREEN**: Add dev server handling section
+- [x] **VERIFY**: Detection order, confirmation, and server start are all documented
+
+### Behavior 4.6: Per-spec delegation to browser-verifier agent
+
+**Given** the command file exists
+**When** we read the test execution section
+**Then** for each spec, it delegates to the browser-verifier agent via Task in test mode, passing all ACs
+
+- [x] **RED**: Grep for browser-verifier delegation -- not found yet
+- [x] **GREEN**: Add the per-spec loop that delegates to the browser-verifier agent with mode: "test"
+- [x] **VERIFY**: The delegation passes spec path and mode: "test"
+
+### Behavior 4.7: Report generation and summary
+
+**Given** the command file exists
+**When** we read the reporting section
+**Then** it describes: one report per spec at `tests/executions/{date}/{specname}-results.md`, directory creation, and console summary ("N of M specs passed")
+
+- [x] **RED**: Grep for "tests/executions" -- not found yet
+- [x] **GREEN**: Add report generation and summary output sections
+- [x] **VERIFY**: Report path pattern, directory creation, and summary format are all present
+
+### Behavior 4.8: Read-only enforcement
+
+**Given** the command file exists
+**When** we read the rules section
+**Then** it explicitly states the command does NOT modify any code (read-only)
+
+- [x] **RED**: Grep for "read-only" or "does NOT modify" -- not found yet
+- [x] **GREEN**: Add explicit read-only rule
+- [x] **VERIFY**: Read-only constraint is stated
+
+- [x] **REFACTOR**: Read the complete command file. Compare structure against `bee/commands/qc.md` for consistency (orchestrator pattern, graceful degradation, tone). Ensure no duplication with the agent definition.
+
+---
+
+## Slice 5: Documentation Updates (CLAUDE.md and help.md)
+
+### Behavior 5.1: CLAUDE.md lists the new command
+
+**Given** `bee/CLAUDE.md` has a "What's Implemented" or "Project Conventions" section listing commands
+**When** we read the implemented commands list
+**Then** `bee:browser-test` is listed with a brief description
+
+- [x] **RED**: Grep `bee/CLAUDE.md` for "browser-test" -- not found yet
+- [x] **GREEN**: Add `bee:browser-test` to the commands list in the appropriate section
+- [x] **VERIFY**: Grep confirms "browser-test" is present in CLAUDE.md
+
+### Behavior 5.2: help.md includes browser-test section
+
+**Given** `bee/commands/help.md` has a numbered tour of commands
+**When** we read the tour
+**Then** there is a new section for `/bee:browser-test` positioned after `/bee:qc`, explaining what it does and how to invoke it
+
+- [x] **RED**: Grep `bee/commands/help.md` for "browser-test" -- not found yet
+- [x] **GREEN**: Add a `/bee:browser-test` section to the tour, after the `/bee:qc` section. Include: what it does (regression testing against running app), invocation example (`/bee:browser-test user-auth checkout-flow`), artifacts produced (report files), read-only nature
+- [x] **VERIFY**: The section is present, positioned after qc, and includes invocation example
+
+### Behavior 5.3: help.md wrap-up summary includes browser-test
+
+**Given** help.md has a wrap-up summary listing all commands
+**When** we read the summary
+**Then** `bee:browser-test` is listed alongside the other commands
+
+- [x] **RED**: Grep the wrap-up section for "browser-test" -- not found yet
+- [x] **GREEN**: Add `bee:browser-test` to the wrap-up summary and the "Skip to specific command" options
+- [x] **VERIFY**: Present in both locations
+
+- [x] **REFACTOR**: Read both files. Ensure the browser-test description is consistent between CLAUDE.md and help.md. Ensure numbering in help.md is correct after the insertion.
+
+---
+
+## Final Check
+
+- [x] **Cross-reference**: Grep all new files for references to each other -- skill references agent, agent references skill, command references agent, build.md references agent
+- [x] **Tool list consistency**: The tools listed in the agent frontmatter match the tools documented in the skill file
+- [x] **Detection order consistency**: Dev server detection order is identical in skill, agent, and command
+- [x] **Degradation mode consistency**: Dev mode (skip) vs test mode (stop) is correctly described in skill, agent, command, and build.md
+- [x] **State tracking consistency**: The "Browser Verification" field format is consistent between the agent and build.md
+- [x] **Read all 5 new/modified files** end-to-end for tone, formatting, and structural consistency with existing bee files
+
+## File Summary
+| Slice | File | Action |
+|-------|------|--------|
+| 1 | `bee/skills/browser-testing/SKILL.md` | Create |
+| 2 | `bee/agents/browser-verifier.md` | Create |
+| 3 | `bee/commands/build.md` | Update Step 4 |
+| 4 | `bee/commands/browser-test.md` | Create |
+| 5 | `bee/CLAUDE.md` | Update commands list |
+| 5 | `bee/commands/help.md` | Update tour + summary |
+
+## Behavior Summary
+| Slice | Behaviors | Status |
+|-------|-----------|--------|
+| 1 - Skill file | 5 | |
+| 2 - Agent definition | 9 | |
+| 3 - Build.md integration | 3 | |
+| 4 - Standalone command | 8 | |
+| 5 - Documentation updates | 3 | |
+| **Total** | **28** | |
+
+---
+
+<p align="center">[x] Reviewed</p>

--- a/docs/specs/browser-visual-verification.md
+++ b/docs/specs/browser-visual-verification.md
@@ -1,0 +1,160 @@
+# Spec: Browser Verification
+
+## Overview
+<!-- -------- bee-comment -------- -->
+> **@developer**: what needs to change such that we do not make the goal of the spec narrow to "visual". I also want to make sure that we look into browser console messages etc.
+> **@bee**: Renamed spec from "Browser Visual Verification" to "Browser Verification". Broadened the overview to explicitly cover console errors, runtime exceptions, and page behavior — not just what's visible on screen.
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+Add browser-based verification to Bee via Chrome MCP tools. The browser verifier checks the running app holistically — visual state, console errors, runtime exceptions, and page behavior — not just what's visible on screen. Two capabilities: (1) a browser-verifier agent that runs after the regular verifier during `bee:build` when UI is involved, and (2) a standalone `bee:browser-test` command for regression testing specs against a running app.
+
+## Capability 1: Browser Verifier Agent (dev mode)
+
+Called by `bee:build` Step 4 as a second Task after the regular verifier passes, only when context-gatherer flagged "UI-involved: yes".
+
+### Dev Server Detection
+<!-- -------- bee-comment -------- -->
+> **@developer**: first method of detection should be trying to get the information from context like CLAUDE.md or chat history
+> **@bee**: Added CLAUDE.md and prior chat context as the primary detection source. Package.json/Makefile analysis is now the fallback, not the first step.
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+- [ ] Agent first checks CLAUDE.md and prior chat context for dev server command and URL (developers often document this)
+- [ ] If not found in context, agent falls back to ecosystem analysis (package.json scripts, Makefile, etc.)
+- [ ] Agent asks the developer: "Should I run {detected-command} and test on {default-uri}, or do you want to provide a different starting point URI?"
+- [ ] Developer can confirm the detected defaults or provide a custom command and/or URI
+- [ ] If no dev server command is detected, agent asks the developer for the command and URI directly
+
+### Chrome MCP Availability
+<!-- -------- bee-comment -------- -->
+> **@developer**: is it possible to check this? how
+> **@bee**: Yes — the agent calls `tabs_context_mcp`. If the Chrome MCP server isn't connected, the tool call returns an error. That error is the detection signal. Updated the AC to make this concrete.
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+- [ ] Agent checks Chrome MCP availability by calling `tabs_context_mcp` — if the call fails or errors, Chrome MCP is not connected
+- [ ] If Chrome MCP is unavailable, agent reports "Browser verification skipped -- Chrome MCP not available" and passes without blocking the build
+- [ ] The regular verifier result (PASS) is not affected by browser verification being unavailable
+
+### Browser Verification
+<!-- -------- bee-comment -------- -->
+> **@developer**: how does it fit in with our existing state tracking? In which step will we be doing this? Will it be specifically one agent's responsibility?
+> **@bee**: Added explicit "Where in the workflow" and "State tracking" sections. Runs in Step 4 of build cycle, after regular verifier passes. The browser-verifier agent (separate agent, not the regular verifier) owns the entire browser interaction. State file gets a "Browser Verification" field per slice: passed/failed/skipped.
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+<!-- -------- bee-comment -------- -->
+> **@developer**: does this mean we will have to change some orchestrator somewhere?
+> **@bee**: Yes — `bee/commands/build.md` is the orchestrator. In Step 4 (Execute → Verify), after the regular verifier Task returns PASS, we add a conditional: if "UI-involved: yes", spawn a second Task to the browser-verifier agent. This is already listed under "Files to Create/Modify → Update: `bee/commands/build.md`" (lines 124-127 of this spec).
+> - [x] mark as resolved
+<!-- -------- /bee-comment -------- -->
+
+**Where in the workflow:** Step 4 (Execute → Verify) of `bee:build`. The build orchestrator calls the browser-verifier agent as a separate Task *after* the regular verifier passes. The browser-verifier agent is solely responsible for all browser interaction.
+
+**State tracking:** `.claude/bee-state.local.md` adds a "Browser Verification" field per slice: `passed`, `failed`, or `skipped (no Chrome MCP)`.
+
+- [ ] Agent reads the spec's acceptance criteria for the current slice
+- [ ] Agent opens the app in Chrome via MCP tools and navigates to the relevant page(s)
+- [ ] Agent uses AI judgment to translate each AC into navigation/interaction/assertion steps (no explicit test scripts)
+- [ ] Agent checks the browser console for errors via `read_console_messages`
+- [ ] Agent reads page content via `read_page` and `get_page_text` to verify AC outcomes
+- [ ] If `.claude/DESIGN.md` exists, agent checks visible UI against design brief constraints (colors, spacing, component usage)
+
+### Dev Mode Reporting
+
+- [ ] Agent only reports failures -- passing ACs are not listed
+- [ ] Console errors are shown in the output
+- [ ] When failures are found, agent asks the developer "Should I go ahead and fix this?"
+- [ ] If no failures and no console errors, agent reports "Browser verification passed" (one line)
+
+## Capability 2: `bee:browser-test` Command (test mode)
+
+Standalone command for regression testing. Read-only -- does NOT modify any code.
+
+### Invocation
+
+- [ ] Command accepts one or more spec file names: `bee:browser-test user-auth checkout-flow`
+- [ ] Spec names resolve to files in `docs/specs/` (with or without `.md` extension)
+- [ ] Shows an error when a specified spec file does not exist
+
+### Dev Server Handling
+
+- [ ] Same detection order as Capability 1 (CLAUDE.md/chat context first, then ecosystem analysis)
+- [ ] Asks the developer to confirm or override the detected command and URI
+- [ ] Starts the dev server if not already running
+
+### Chrome MCP Availability
+
+- [ ] Checks for Chrome MCP tools before starting
+- [ ] If Chrome MCP is unavailable, reports the error and stops (unlike dev mode, there is no fallback -- browser testing is the whole point)
+
+### Test Execution
+
+- [ ] For each spec file, reads all acceptance criteria
+- [ ] Navigates the app and uses AI judgment to verify each AC
+- [ ] Checks browser console for errors
+- [ ] Takes screenshots for both passing and failing ACs
+- [ ] If `.claude/DESIGN.md` exists, checks UI against design brief constraints
+
+### Test Mode Reporting
+
+- [ ] Produces a full report with each AC marked PASS or FAILED
+- [ ] Failed ACs include a description of what was expected vs. what was observed
+- [ ] Console errors are listed in the report
+- [ ] Screenshot file paths are referenced in the report
+- [ ] Report is saved to `tests/executions/{YYYY-MM-DD}/{specname}-results.md`
+- [ ] Creates the directory structure if it does not exist
+- [ ] When testing multiple specs, produces one report file per spec
+- [ ] Prints a summary to the console: "N of M specs passed. Reports saved to tests/executions/{date}/"
+
+## Files to Create/Modify
+
+### New: `bee/agents/browser-verifier.md`
+
+Agent definition with:
+- YAML frontmatter: name, description, tools (including Chrome MCP tool names), model: inherit
+- Tools must include: Read, Glob, Grep, Bash, tabs_create_mcp, navigate, read_page, find, computer, javascript_tool, read_console_messages, get_page_text
+
+### New: `bee/commands/browser-test.md`
+
+Command definition with:
+- YAML frontmatter: description
+- Orchestrates: dev server detection, Chrome MCP check, spec file resolution, browser-verifier agent delegation (in test mode), report generation
+
+### New: `bee/skills/browser-testing/SKILL.md`
+
+Shared skill referenced by both the agent and command:
+- Dev server detection patterns (package.json scripts, Makefile, common frameworks)
+- Chrome MCP tool usage patterns (which tool for what purpose)
+- Graceful degradation approach
+- Screenshot capture conventions
+
+### Update: `bee/commands/build.md`
+
+- In Step 4 (Execute -> Verify), after the regular verifier passes: if "UI-involved: yes", delegate to browser-verifier agent via Task in dev mode
+- Pass: spec path, slice number, context summary (including dev server info)
+
+### Update: `bee/CLAUDE.md`
+
+- Add `bee:browser-test` to the implemented commands list under Project Conventions
+
+### Update: `bee/commands/help.md`
+
+- Add `/bee:browser-test` as a new section in the tour, after `/bee:qc`
+
+## Out of Scope
+
+- No mobile/responsive viewport testing -- desktop browser only
+- No visual diff/pixel comparison -- AI judgment only, no image diffing tools
+- No parallel browser sessions -- specs tested sequentially
+- No test recording/playback -- every run is AI-interpreted fresh
+- No modification of production code from `bee:browser-test` (strictly read-only)
+- No automatic retry of failed ACs -- report and stop
+
+## Technical Context
+
+- Patterns to follow: agent frontmatter matches existing agents (see `verifier.md`, `quick-fix.md`); command structure matches `qc.md` for standalone orchestration
+- Key dependencies: Chrome MCP tools (external), context-gatherer's "UI-involved" flag, existing verifier agent (runs first, browser-verifier runs second)
+- The `qc.md` command is the closest template for ecosystem detection and graceful degradation patterns
+- Risk level: LOW (internal tooling, no production code changes)
+
+---
+
+<p align="center">[x] Reviewed</p>


### PR DESCRIPTION
## Summary
- New `browser-verifier` agent that checks running apps via Chrome MCP — visual state, console errors, runtime exceptions
- New `bee:browser-test` standalone command for multi-spec regression testing with pass/fail reports and screenshots
- Integrated into `bee:build` Step 4 — auto-triggers browser verification when UI is involved
- New `browser-testing` skill with Chrome MCP tool reference, dev server detection patterns, and graceful degradation

## Files
- **New:** `bee/agents/browser-verifier.md`, `bee/commands/browser-test.md`, `bee/skills/browser-testing/SKILL.md`
- **Updated:** `bee/commands/build.md` (Step 4), `bee/CLAUDE.md`, `bee/commands/help.md`
- **Specs:** `docs/specs/browser-visual-verification.md`, `docs/specs/browser-verification-tdd-plan.md`

## Test plan
- [x] All 28 TDD plan behaviors verified (structural verification — markdown-only project)
- [x] Cross-references consistent across all files (skill ↔ agent ↔ command ↔ build.md)
- [x] Patterns match existing agents/commands/skills
- [x] Documentation updated (CLAUDE.md, help.md tour + wrap-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)