### PR TITLE
Add Codex Bee/Learn adapters and compatibility mapping

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,43 @@
+# Bee + Learn + Codex CLI
+
+This directory provides Codex-compatible command prompts for the Bee and Learn Claude plugins.
+
+## Install (cross-platform)
+
+Use the installer script from the repo root:
+
+- macOS/Linux:
+  - `python3 .codex/scripts/install_prompts.py`
+- Windows (PowerShell):
+  - `py .codex/scripts/install_prompts.py`
+
+The script installs Bee prompt files into:
+
+- `$CODEX_HOME/prompts` (if `CODEX_HOME` is set), or
+- `~/.codex/prompts` (default)
+
+### Useful options
+
+- Dry run:
+  - `python3 .codex/scripts/install_prompts.py --dry-run`
+- Overwrite existing prompts:
+  - `python3 .codex/scripts/install_prompts.py --force`
+- Custom target directory:
+  - `python3 .codex/scripts/install_prompts.py --target /path/to/prompts`
+
+## Usage
+
+After install, invoke commands by filename, for example:
+
+- `/bee`
+- `/bee-review`
+- `/bee-qc`
+- `/learn`
+- `/learn-start`
+- `/learn-next`
+
+## Notes
+
+- These prompts reference Claude plugin files under `bee/` and `learn/`.
+- Codex does not support Claude-only tools (`Task`, `AskUserQuestion`, `Skill`). See `.codex/commands/CODEX_COMPATIBILITY.md` for substitutions.
+- The Bee and Learn plugins remain unchanged; Codex commands are adapters only.

--- a/.codex/commands/CODEX_COMPATIBILITY.md
+++ b/.codex/commands/CODEX_COMPATIBILITY.md
@@ -1,0 +1,23 @@
+# Codex Compatibility Guide (Bee + Learn)
+
+Codex CLI cannot invoke Claude-specific tools (`Task`, `AskUserQuestion`, `Skill`, `TodoWrite`) or spawn subagents. Use the substitutions below when running Bee or Learn commands via Codex.
+
+## Tool substitutions
+
+- `Task` / subagents: Execute the described steps yourself, sequentially. Note intended parallelism but do not call Task.
+- `AskUserQuestion`: Ask the user inline with the same options and proceed based on the answer.
+- `Skill(name)`: Open the skill file directly from the active plugin path and follow its SOP manually (`bee/skills/<skill>/SKILL.md` for Bee commands, `learn/skills/<skill>/SKILL.md` for Learn commands).
+- `TodoWrite`: Edit the referenced file directly (if any), keeping updates atomic.
+
+## Command mapping
+
+- `/bee` entry point: Follow `bee/commands/build.md` as the primary orchestrator.
+- `/bee:<command>`: Open the matching command in `bee/commands/` and follow it directly.
+- `/learn` entry point: Follow `learn/commands/start.md` as the primary orchestrator.
+- `/learn:<command>`: Open the matching command in `learn/commands/` and follow it directly.
+
+## When a Bee command says…
+
+- “Spawn agents in parallel” -> Run them one-by-one in the same session.
+- “Use AskUserQuestion” -> Ask the question in chat with the listed options.
+- “Use Skill tool” -> Read the skill file from disk and apply its guidance.

--- a/.codex/commands/README.md
+++ b/.codex/commands/README.md
@@ -1,0 +1,31 @@
+# Bee + Learn Codex Commands
+
+**Location**: `.codex/commands/`
+
+These are Codex-compatible adapters for the Bee and Learn Claude plugins.
+
+## Commands
+
+- `/bee` - Bee workflow navigator entry point (Codex adapter).
+- `/bee-architect` - Adapter for `/bee:architect`.
+- `/bee-browser-test` - Adapter for `/bee:browser-test`.
+- `/bee-build` - Adapter for `/bee:build`.
+- `/bee-coach` - Adapter for `/bee:coach`.
+- `/bee-discover` - Adapter for `/bee:discover`.
+- `/bee-help` - Adapter for `/bee:help`.
+- `/bee-migrate` - Adapter for `/bee:migrate`.
+- `/bee-onboard` - Adapter for `/bee:onboard`.
+- `/bee-qc` - Adapter for `/bee:qc`.
+- `/bee-review` - Adapter for `/bee:review`.
+- `/learn` - Learn teaching workflow entry point (Codex adapter).
+- `/learn-analyze` - Adapter for `/learn:analyze`.
+- `/learn-explain` - Adapter for `/learn:explain`.
+- `/learn-help` - Adapter for `/learn:help`.
+- `/learn-next` - Adapter for `/learn:next`.
+- `/learn-quiz` - Adapter for `/learn:quiz`.
+- `/learn-review` - Adapter for `/learn:review`.
+- `/learn-start` - Adapter for `/learn:start`.
+
+## Compatibility
+
+See `CODEX_COMPATIBILITY.md` for required tool substitutions.

--- a/.codex/commands/bee-architect.md
+++ b/.codex/commands/bee-architect.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:architect (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:architect (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:architect`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/architect.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-browser-test.md
+++ b/.codex/commands/bee-browser-test.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:browser-test (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:browser-test (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:browser-test`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/browser-test.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-build.md
+++ b/.codex/commands/bee-build.md
@@ -1,0 +1,20 @@
+---
+description: Bee build orchestrator (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:build (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:build`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/build.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-coach.md
+++ b/.codex/commands/bee-coach.md
@@ -1,0 +1,20 @@
+---
+description: Bee coaching (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:coach (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:coach`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/coach.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-discover.md
+++ b/.codex/commands/bee-discover.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:discover (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:discover (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:discover`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/discover.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-help.md
+++ b/.codex/commands/bee-help.md
@@ -1,0 +1,20 @@
+---
+description: Bee help (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:help (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:help`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/help.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-migrate.md
+++ b/.codex/commands/bee-migrate.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:migrate (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:migrate (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:migrate`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/migrate.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-onboard.md
+++ b/.codex/commands/bee-onboard.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:onboard (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:onboard (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:onboard`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/onboard.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-qc.md
+++ b/.codex/commands/bee-qc.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:qc (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:qc (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:qc`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/qc.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee-review.md
+++ b/.codex/commands/bee-review.md
@@ -1,0 +1,20 @@
+---
+description: Bee adapter for /bee:review (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee /bee:review (Codex Adapter)
+
+This is the Codex-compatible adapter for the Bee command `/bee:review`.
+
+## How to run
+
+1. Read `bee/CLAUDE.md` for Bee's role, workflow, and conventions.
+2. Follow the command in `bee/commands/review.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/bee.md
+++ b/.codex/commands/bee.md
@@ -1,0 +1,25 @@
+---
+description: Bee workflow navigator entry point (Codex-compatible)
+arguments: ["request"]
+---
+
+# Bee (Codex Adapter)
+
+Use this command as the Codex-compatible entry point for the Bee Claude plugin.
+
+## How to run Bee in Codex
+
+1. Read `bee/CLAUDE.md` to load Bee's role, workflow, and conventions.
+2. Follow the orchestrator in `bee/commands/build.md` as the primary entry point for `/bee`.
+3. When Bee routes to a subcommand (for example `/bee:review`, `/bee:qc`, `/bee:discover`, `/bee:architect`, `/bee:onboard`, `/bee:browser-test`, `/bee:migrate`), open the matching file under `bee/commands/` and follow it directly.
+4. Apply the substitutions in `CODEX_COMPATIBILITY.md` whenever a Bee command references Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `bee/skills/<skill>/SKILL.md` directly.
+
+## Start
+
+Ask the user for their request if it was not provided, then begin the Bee workflow using `bee/commands/build.md`.

--- a/.codex/commands/learn-analyze.md
+++ b/.codex/commands/learn-analyze.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:analyze (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:analyze (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:analyze`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/analyze.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-explain.md
+++ b/.codex/commands/learn-explain.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:explain (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:explain (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:explain`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/explain.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-help.md
+++ b/.codex/commands/learn-help.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:help (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:help (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:help`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/help.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-next.md
+++ b/.codex/commands/learn-next.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:next (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:next (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:next`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/next.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-quiz.md
+++ b/.codex/commands/learn-quiz.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:quiz (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:quiz (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:quiz`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/quiz.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-review.md
+++ b/.codex/commands/learn-review.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:review (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:review (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:review`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/review.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn-start.md
+++ b/.codex/commands/learn-start.md
@@ -1,0 +1,20 @@
+---
+description: Learn adapter for /learn:start (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn /learn:start (Codex Adapter)
+
+This is the Codex-compatible adapter for the Learn command `/learn:start`.
+
+## How to run
+
+1. Read `learn/CLAUDE.md` for Learn's teaching style and conventions.
+2. Follow the command in `learn/commands/start.md` directly.
+3. Apply the substitutions in `CODEX_COMPATIBILITY.md` for any Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.

--- a/.codex/commands/learn.md
+++ b/.codex/commands/learn.md
@@ -1,0 +1,25 @@
+---
+description: Learn teaching workflow entry point (Codex-compatible)
+arguments: ["request"]
+---
+
+# Learn (Codex Adapter)
+
+Use this command as the Codex-compatible entry point for the Learn Claude plugin.
+
+## How to run Learn in Codex
+
+1. Read `learn/CLAUDE.md` to load Learn's teaching style and workflow.
+2. Follow the orchestrator in `learn/commands/start.md` as the primary entry point for `/learn`.
+3. When Learn routes to a subcommand (for example `/learn:next`, `/learn:explain`, `/learn:quiz`, `/learn:analyze`, `/learn:review`, `/learn:help`), open the matching file under `learn/commands/` and follow it directly.
+4. Apply the substitutions in `CODEX_COMPATIBILITY.md` whenever a Learn command references Claude-only tools.
+
+## Codex substitutions (summary)
+
+- No `Task` or subagents: run steps sequentially.
+- No `AskUserQuestion`: ask the user inline with the same options.
+- No `Skill`: open `learn/skills/<skill>/SKILL.md` directly.
+
+## Start
+
+Ask the user what they want to learn if it was not provided, then begin with `learn/commands/start.md`.

--- a/.codex/scripts/install_prompts.py
+++ b/.codex/scripts/install_prompts.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Install Bee/Learn Codex prompt files into the user's Codex prompts directory.
+
+Default target directory:
+- $CODEX_HOME/prompts if CODEX_HOME is set
+- ~/.codex/prompts otherwise
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import sys
+
+
+def default_target() -> Path:
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "prompts"
+    return Path.home() / ".codex" / "prompts"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install Bee/Learn Codex commands into a Codex prompts directory."
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=default_target(),
+        help="Destination prompts directory (default: $CODEX_HOME/prompts or ~/.codex/prompts)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files in the target directory.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be copied without writing files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    source_dir = repo_root / ".codex" / "commands"
+
+    if not source_dir.exists():
+        print(f"error: source directory not found: {source_dir}", file=sys.stderr)
+        return 1
+
+    # Install executable command prompts plus compatibility guidance
+    # referenced by those prompts.
+    sources = sorted(
+        [
+            path
+            for path in source_dir.glob("*.md")
+            if (
+                path.name.startswith(("bee", "learn"))
+                or path.name == "CODEX_COMPATIBILITY.md"
+            )
+            and path.name != "README.md"
+        ]
+    )
+    if not sources:
+        print(f"error: no Bee/Learn prompt files found in {source_dir}", file=sys.stderr)
+        return 1
+
+    target = args.target.expanduser().resolve()
+
+    print(f"source: {source_dir}")
+    print(f"target: {target}")
+    print(f"mode: {'dry-run' if args.dry_run else 'install'}")
+
+    if not args.dry_run:
+        target.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    skipped = 0
+
+    for src in sources:
+        dst = target / src.name
+        if dst.exists() and not args.force:
+            skipped += 1
+            print(f"skip   {src.name} (exists; use --force to overwrite)")
+            continue
+
+        action = "copy" if not dst.exists() else "update"
+        print(f"{action:6} {src.name}")
+
+        if not args.dry_run:
+            shutil.copy2(src, dst)
+        copied += 1
+
+    print(f"\nsummary: copied={copied}, skipped={skipped}, total={len(sources)}")
+
+    if skipped > 0 and not args.force:
+        print("note: rerun with --force to overwrite existing prompts")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add Codex-compatible Bee and Learn prompt adapters under .codex/command
- add compatibility guide for Claude-only tool substitutions
- add installer script for prompt installation into Codex prompts directory

## Testing

> python3 .codex/scripts/install_prompts.py --dry-run