### PR TITLE
Ensure spec is single source of truth for slice order

### DIFF
--- a/bee/README.md
+++ b/bee/README.md
@@ -213,7 +213,7 @@ Bee assesses every task on two axes — **size** and **risk** — then recommend
 | Artifact       | Location                                   | Purpose                                           |
 | -------------- | ------------------------------------------ | ------------------------------------------------- |
 | Design Brief   | `.claude/DESIGN.md`                        | Project-level visual constraints for UI work      |
-| Specs          | `docs/specs/[feature].md`                  | Requirements with acceptance criteria             |
+| Specs          | `docs/specs/[feature]-spec.md`             | Requirements with acceptance criteria             |
 | Discovery Docs | `docs/specs/[feature]-discovery.md`        | Problem statement, hypotheses, milestone map      |
 | ADRs           | `docs/adrs/NNN-[decision].md`              | Architecture decisions with rationale             |
 | State          | `.claude/bee-state.local.md`               | Session resume tracking                           |

--- a/bee/agents/architecture-impl-advisor.md
+++ b/bee/agents/architecture-impl-advisor.md
@@ -104,7 +104,19 @@ If no existing pattern or if greenfield:
 3. Pick the **simplest pattern that fits**
 4. Identify natural seams (external APIs, data stores, third-party services)
 
-### 4. Present the Recommendation
+### 4. Evaluate Slice Order
+
+Read the spec's slices in order. For each slice, check:
+- Can this slice run/verify independently assuming only prior slices exist?
+- Does it depend on code from a later slice?
+
+If a later slice provides dependencies that earlier slices need, recommend reordering.
+
+Principle: each slice should be independently releasable — if we stop after any slice, the project runs and everything built so far is verifiable. MVP mindset.
+
+If the current spec order already satisfies this: say nothing about ordering. Only recommend reordering when a dependency violation exists.
+
+### 5. Present the Recommendation
 
 Use AskUserQuestion to present your recommendation as the first option, with 1-2 alternatives:
 
@@ -112,7 +124,7 @@ Example:
 - "Feature Folders (Recommended)" — "Simplest fit. Co-locate each feature's logic, types, and tests."
 - "MVC" — "If you prefer traditional layers. More ceremony but familiar."
 
-### 5. Produce the Architecture Output
+### 6. Produce the Architecture Output
 
 After the developer confirms, output the architecture recommendation in this format:
 
@@ -129,6 +141,10 @@ After the developer confirms, output the architecture recommendation in this for
 - "[condition] → [what to extract or restructure]"
 - "[condition] → [what to extract or restructure]"
 - "[condition] → [what to extract or restructure]"
+
+## Slice Order (only if reorder needed)
+[original order] → [recommended order]
+Reason: [which slice depends on which — why the original order breaks independent releasability]
 ```
 
 Evolution triggers are concrete and actionable. Examples:

--- a/bee/agents/spec-builder.md
+++ b/bee/agents/spec-builder.md
@@ -136,7 +136,7 @@ NOT Given/When/Then. NOT multi-paragraph descriptions. Just clear, testable stat
 
 ## Output Format
 
-Save to `docs/specs/[feature-name].md`:
+Save to `docs/specs/[feature-name]-spec.md`:
 
 ### Single-Slice Feature (FEATURE size)
 

--- a/bee/commands/sdd.md
+++ b/bee/commands/sdd.md
@@ -295,8 +295,8 @@ Delegate to the **spec-builder** agent via Task, passing:
 - The triage assessment (size + risk — possibly revised by discovery)
 - The context summary from the context-gatherer
 - The discovery document path (if discovery was done)
-- For multi-phase: which phase to spec (number + name from milestone map). Spec saves to `docs/specs/[feature]-phase-N.md`.
-- For single-phase: no phase constraint. Spec saves to `docs/specs/[feature].md`.
+- For multi-phase: which phase to spec (number + name from milestone map). Spec saves to `docs/specs/[feature]-phase-N-spec.md`.
+- For single-phase: no phase constraint. Spec saves to `docs/specs/[feature]-spec.md`.
 
 The spec-builder interviews the developer, writes the spec to `docs/specs/`, and gets confirmation before returning.
 **→ Update state:** `"${CLAUDE_PLUGIN_ROOT}/scripts/update-bee-state.sh" set --phase-spec "[spec-path] — confirmed" --current-phase "spec confirmed"`

--- a/bee/commands/sdd.md
+++ b/bee/commands/sdd.md
@@ -120,6 +120,8 @@ The advisor evaluates the codebase and spec, presents architecture options to th
 
 Save the architecture output — you'll pass it to every slice-coder invocation.
 
+If the architecture advisor recommended a slice reorder: update the spec file to reflect the new order. Reorder the `### Slice` sections in the spec to match the recommended order. Keep slice content intact — only move sections. This ensures the spec file is always the single source of truth for execution order.
+
 **→ Update state:** `"${CLAUDE_PLUGIN_ROOT}/scripts/update-bee-state.sh" set --architecture "[pattern] — [summary]" --current-phase "architecture decided"`
 
 **→ Run the Collaboration Loop** on the architecture recommendation.
@@ -129,6 +131,8 @@ Save the architecture output — you'll pass it to every slice-coder invocation.
 Show the developer the slices in order with their ACs. Use AskUserQuestion:
 "Here's the SDD plan — **[N] slices**. I'll code each slice, then test it. Ready?"
 Options: "Yes, let's go (Recommended)" / "I want to reorder"
+
+If the developer chooses to reorder: get the new order, then update the spec file to match. Reorder the `### Slice` sections — keep content intact, only move sections. The spec is always the single source of truth.
 
 Then proceed to **The Slice Loop**.
 
@@ -307,6 +311,9 @@ Delegate to the **architecture-impl-advisor** agent via Task, passing:
 - The triage assessment (size + risk)
 
 The advisor evaluates options and returns the architecture recommendation.
+
+If the architecture advisor recommended a slice reorder: update the spec file to reflect the new order. Reorder the `### Slice` sections in the spec to match the recommended order. Keep slice content intact — only move sections. This ensures the spec file is always the single source of truth for execution order.
+
 **→ Update state:** `"${CLAUDE_PLUGIN_ROOT}/scripts/update-bee-state.sh" set --architecture "[pattern] — [summary]" --current-phase "architecture decided"`
 
 **→ Run the Collaboration Loop** on the architecture recommendation.
@@ -320,6 +327,8 @@ Read the spec. Show the developer the slices in order with their ACs. Use AskUse
 "Here's the SDD plan — **[N] slices**. I'll code each slice, then test it. Ready?"
 Options: "Yes, let's go (Recommended)" / "I want to reorder"
 
+If the developer chooses to reorder: get the new order, then update the spec file to match. Reorder the `### Slice` sections — keep content intact, only move sections. The spec is always the single source of truth.
+
 Then proceed to **The Slice Loop**.
 
 ---
@@ -328,7 +337,7 @@ Then proceed to **The Slice Loop**.
 
 **Recap context:** As you run the slice loop, accumulate a recap context to pass to the recap agent at the end. After each slice-coder returns, note the source files and what was done. After each slice-tester returns, note the test files. After the verifier returns, note its summary. This is passed to the recap agent — it does NOT depend on git commits.
 
-For each slice, in order:
+For each slice, in the order they appear in the spec file. Never reorder, skip, or rearrange — the spec is the single source of truth for slice order:
 
 ### Step A — Create a Task
 

--- a/bee/skills/collaboration-loop/SKILL.md
+++ b/bee/skills/collaboration-loop/SKILL.md
@@ -109,7 +109,7 @@ Only `[x] Reviewed` blocks progression. These do NOT block:
 
 This loop applies after these agents return:
 - Discovery agent → `docs/specs/[feature]-discovery.md`
-- Spec-builder → `docs/specs/[feature].md` or `docs/specs/[feature]-phase-N.md`
+- Spec-builder → `docs/specs/[feature]-spec.md` or `docs/specs/[feature]-phase-N-spec.md`
 - TDD planner (all 5 variants) → `docs/specs/[feature]-slice-N-tdd-plan.md`
 
 It does NOT apply to: quick-fix, context-gatherer, tidy, architecture-advisor, verifier, reviewer.


### PR DESCRIPTION
## Summary
- Architecture advisor now evaluates slice ordering for dependency correctness and independent releasability (MVP mindset — each slice should be releasable on its own)
- If reorder is needed, the spec file itself is updated — no more invisible reordering at execution time
- Slice loop strictly follows spec order: "Never reorder, skip, or rearrange"
- Developer "I want to reorder" choice also writes back to spec

## Test plan
- [ ] Run `/bee:sdd` with a spec that has dependency-violating slice order — verify architecture advisor recommends reorder and spec file is updated
- [ ] Run `/bee:sdd` with a spec in correct order — verify no reorder is suggested
- [ ] Verify slice loop follows spec order strictly after reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)