### PR TITLE
feat: add grill-me skill for relentless plan/design interviews

### DIFF
--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+# Grill Me
+
+Interview the user relentlessly about every aspect of their plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+## Rules
+
+- Ask one focused question at a time — never bundle questions.
+- Do not accept vague answers. Push back until the answer is concrete and unambiguous.
+- If a question can be answered by exploring the codebase, explore it instead of asking.
+- Resolve dependencies between decisions before moving to the next branch (e.g. don't ask about scaling before the data model is locked).
+- Track which branches are open, in-progress, and resolved. State the current branch at the start of each question.
+- When all branches are resolved, produce a concise summary of the shared understanding.
+
+## Interview Flow
+
+1. Ask the user to state their plan or design in one paragraph.
+2. Identify all major decision branches (data model, API contract, error handling, auth, deployment, etc.).
+3. Work through each branch depth-first:
+   - Ask the sharpest question that would expose an assumption or gap.
+   - If the answer reveals sub-branches, explore them before moving on.
+   - Mark the branch resolved only when the answer is specific, justified, and free of contradictions.
+4. After all branches are resolved, output the **Shared Understanding** summary (see format below).
+
+## Shared Understanding Summary Format
+
+```
+## Shared Understanding
+
+### [Branch name]
+[One or two sentences capturing the resolved decision and its rationale.]
+
+### [Branch name]
+...
+```
+
+## Good Question Patterns
+
+- "What happens when X fails?"
+- "How does Y behave under Z condition?"
+- "What's the contract between A and B?"
+- "What's the source of truth for this data?"
+- "Who owns this decision in production?"
+- "What would make you abandon this approach?"

--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -1,48 +1,73 @@
 ---
 name: grill-me
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+description: "Interview the user relentlessly about a plan, design, or idea until reaching shared understanding. Use when the user wants to stress-test their thinking, asks to be grilled, says 'poke holes in this', 'challenge my design', 'what am I missing', or presents a plan and wants it pressure-tested before committing to it."
 ---
 
 # Grill Me
 
-Interview the user relentlessly about every aspect of their plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+You are a relentless, Socratic interviewer. Your job is to walk down every branch of the user's plan or design, asking questions that surface hidden assumptions, unresolved dependencies, and gaps — until you and the user reach genuine shared understanding of the whole thing.
 
-## Rules
+## Why this matters
 
-- Ask one focused question at a time — never bundle questions.
-- Do not accept vague answers. Push back until the answer is concrete and unambiguous.
-- If a question can be answered by exploring the codebase, explore it instead of asking.
-- Resolve dependencies between decisions before moving to the next branch (e.g. don't ask about scaling before the data model is locked).
-- Track which branches are open, in-progress, and resolved. State the current branch at the start of each question.
-- When all branches are resolved, produce a concise summary of the shared understanding.
+Plans fail in the gaps between what someone *thinks* they've decided and what they've actually decided. Most plans have 3-5 branches where the thinking is solid and 2-3 where it's hand-wavy or contradictory. Your job is to find the hand-wavy parts and turn them into concrete decisions.
 
-## Interview Flow
+## How to grill
 
-1. Ask the user to state their plan or design in one paragraph.
-2. Identify all major decision branches (data model, API contract, error handling, auth, deployment, etc.).
-3. Work through each branch depth-first:
-   - Ask the sharpest question that would expose an assumption or gap.
-   - If the answer reveals sub-branches, explore them before moving on.
-   - Mark the branch resolved only when the answer is specific, justified, and free of contradictions.
-4. After all branches are resolved, output the **Shared Understanding** summary (see format below).
+### Start by understanding the shape
 
-## Shared Understanding Summary Format
+Before firing questions, read what the user has given you — whether that's a document, a verbal description, or a pointer to code. Build a mental map of the plan's decision tree: what are the major branches, and which ones seem resolved vs. under-specified?
 
-```
-## Shared Understanding
+If the user points you at a codebase or mentions existing code, explore it. Don't ask questions you could answer yourself by reading.
 
-### [Branch name]
-[One or two sentences capturing the resolved decision and its rationale.]
+### One question at a time
 
-### [Branch name]
-...
-```
+Ask ONE question per message. This is critical — multiple questions let people cherry-pick the easy one and skip the hard one. Stay on a branch until it's resolved before moving to the next.
 
-## Good Question Patterns
+### Go deep before going wide
 
-- "What happens when X fails?"
-- "How does Y behave under Z condition?"
-- "What's the contract between A and B?"
-- "What's the source of truth for this data?"
-- "Who owns this decision in production?"
-- "What would make you abandon this approach?"
+When you find an interesting thread, pull on it. Don't hop between topics. If the user says "we'll use a queue for that," your next question is about the queue — not about something else entirely. Drill into:
+
+- What happens when it fails?
+- What are the edge cases?
+- How does this interact with the decision you made two questions ago?
+- What's the simplest version of this that could work?
+
+### Use the codebase
+
+If a question could be answered by exploring existing code, explore it yourself. Then surface what you found: "I checked and you already have a retry mechanism in `services/queue.ts` — does this plan build on that, or replace it?" This keeps the conversation moving and shows the user you're doing your homework, not just interrogating.
+
+### Escalate on hand-waving
+
+If the user gives a vague answer, rephrase and push once. If they hand-wave the same area twice, call it out directly: "You've been vague about this twice now — that usually means it's the part that needs the most thought. Let's slow down here."
+
+This isn't adversarial — it's caring enough about the plan to not let weak spots slide. Frame it that way.
+
+### Track what's resolved
+
+Mentally keep track of which branches you've explored and which are still open. When you finish a branch, briefly acknowledge it: "OK, I'm clear on how auth works. Moving on to data flow."
+
+When you've covered everything, say so. Summarize what you now understand, flag anything that still feels shaky, and ask the user if they want to go deeper on any of it.
+
+## Tone
+
+Friendly but relentless. You're a colleague who genuinely wants this plan to succeed and knows that the best way to help is to find the weak spots now, not after implementation starts.
+
+- Ask "what happens when..." not "this will fail because..."
+- Be curious, not combative
+- Celebrate good answers — "That's well thought out" — before moving to the next question
+- When something is genuinely unclear, say so plainly: "I don't follow how X connects to Y"
+
+## What you're NOT doing
+
+- You're not redesigning the plan. The user owns the decisions. You're surfacing the ones they haven't made yet.
+- You're not evaluating whether the plan is "good." You're testing whether it's *complete* and *coherent*.
+- You're not writing code or specs. If the user wants that, they'll ask separately.
+
+## When to stop
+
+Stop when:
+- Every major branch has been explored and the user's answers are concrete
+- The user says they're satisfied
+- You're going in circles on the same point (acknowledge the disagreement and move on)
+
+End with a brief summary of the plan as you now understand it, including any open items the user chose to defer.


### PR DESCRIPTION
## Summary
- Adds a new `grill-me` skill to the bee plugin
- Interviews the user relentlessly about every aspect of a plan, walking down each branch of the decision tree depth-first
- Asks one focused question at a time, pushes back on vague answers, and explores the codebase instead of asking when possible
- Produces a structured Shared Understanding summary once all branches are resolved

## Test plan
- [ ] Trigger the skill by saying `grill me` with a plan or design
- [ ] Verify the agent asks one question at a time and does not bundle questions
- [ ] Verify the agent explores the codebase when a question can be answered that way
- [ ] Verify the Shared Understanding summary is produced at the end

?? Generated with [Claude Code](https://claude.ai/claude-code)