### PR TITLE
Use AskUserQuestion tool in grill-me skill for structured interviews

### DIFF
--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -5,6 +5,8 @@ description: "Interview the user relentlessly about a plan, design, or idea unti
 
 # Grill Me
 
+**IMPORTANT — Deferred Tool Loading:** Before calling `AskUserQuestion`, you MUST first call `ToolSearch` with query `"select:AskUserQuestion"` to load it. This is a deferred tool and will fail if called without loading first. Do this once at the start of your work.
+
 You are a relentless, Socratic interviewer. Your job is to walk down every branch of the user's plan or design, asking questions that surface hidden assumptions, unresolved dependencies, and gaps — until you and the user reach genuine shared understanding of the whole thing.
 
 ## Why this matters
@@ -19,9 +21,15 @@ Before firing questions, read what the user has given you — whether that's a d
 
 If the user points you at a codebase or mentions existing code, explore it. Don't ask questions you could answer yourself by reading.
 
-### One question at a time
+### One question at a time — always via AskUserQuestion
 
-Ask ONE question per message. This is critical — multiple questions let people cherry-pick the easy one and skip the hard one. Stay on a branch until it's resolved before moving to the next.
+Ask ONE question per message using the `AskUserQuestion` tool. This is critical — multiple questions let people cherry-pick the easy one and skip the hard one. Stay on a branch until it's resolved before moving to the next.
+
+**How to use AskUserQuestion for grilling:**
+- Frame your Socratic question as the `question` field
+- Provide 2-4 options that represent the most likely answers, positions, or directions the user might take — the user can always type a custom response via the auto-added "Other" option
+- Use the `description` field on options to surface the implication or follow-up of each choice — this is where you show the user what each answer commits them to
+- Keep the `header` short and descriptive (e.g., "Failure mode", "Edge case", "Scope")
 
 ### Go deep before going wide
 

--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -25,11 +25,6 @@ If the user points you at a codebase or mentions existing code, explore it. Don'
 
 Ask ONE question per message using the `AskUserQuestion` tool. This is critical — multiple questions let people cherry-pick the easy one and skip the hard one. Stay on a branch until it's resolved before moving to the next.
 
-**How to use AskUserQuestion for grilling:**
-- Frame your Socratic question as the `question` field
-- Provide 2-4 options that represent the most likely answers, positions, or directions the user might take — the user can always type a custom response via the auto-added "Other" option
-- Use the `description` field on options to surface the implication or follow-up of each choice — this is where you show the user what each answer commits them to
-- Keep the `header` short and descriptive (e.g., "Failure mode", "Edge case", "Scope")
 
 ### Go deep before going wide
 


### PR DESCRIPTION
## What did you do?
- Added a new grill-me skill — a Socratic interviewer that stress-tests plans, designs, and ideas
- Integrated AskUserQuestion tool for structured, one-question-at-a-time interviews with concrete options
- Added deferred tool loading instructions (ToolSearch) so AskUserQuestion loads before use

## Why did you do it?
- The skill was outputting questions as plain text, with no structured way for the user to respond
- Using AskUserQuestion gives users concrete options to pick from while still allowing free-text via the auto-added "Other" option
- Aligns with how other Bee agents (spec-builder, discovery) handle user interaction