### PR TITLE
Update grill-me to build context incrementally

### DIFF
--- a/bee/commands/sdd.md
+++ b/bee/commands/sdd.md
@@ -207,9 +207,9 @@ Pass the developer's answers as enriched context to every downstream agent.
 
 ### B2.3. Grill-Me Decisions (When Used)
 
-If the developer invoked grill-me (e.g., `/bee:sdd /grill-me "description"` or the grill-me skill was loaded during this session), you will have had a deep Q&A with the developer before reaching this point. Those decisions are in your conversation context but will be **lost** when you delegate to subagents via Task.
+If the developer invoked grill-me (e.g., `/bee:sdd /grill-me "description"` or the grill-me skill was loaded during this session), the grill-me skill **builds `.claude/bee-context.local.md` incrementally** — appending each resolved decision as it happens during the interview. By the time grill-me concludes, the file already contains all decisions and open items. No post-session capture needed.
 
-**Capture them now.** After the grill-me session concludes, write a structured summary of all decisions and resolved questions to `.claude/bee-context.local.md` using Bash:
+**Verify the file exists.** After grill-me completes, confirm `.claude/bee-context.local.md` exists and has content. If for some reason it doesn't (e.g., grill-me was run standalone outside SDD), capture the decisions now:
 
 ```bash
 mkdir -p .claude && cat > .claude/bee-context.local.md << 'GRILLME_EOF'
@@ -217,14 +217,13 @@ mkdir -p .claude && cat > .claude/bee-context.local.md << 'GRILLME_EOF'
 
 [For each resolved question/decision from the grill-me session:]
 - **[Topic]**: [Decision made and rationale]
-- **[Topic]**: [Decision made and rationale]
 
 ### Open Items
 [Anything the developer chose to defer — list here so spec-builder can address them]
 GRILLME_EOF
 ```
 
-This seeds the context file. When context-gatherer runs later (B3), **append** its output to this file instead of overwriting:
+When context-gatherer runs later (B3), **append** its output to this file instead of overwriting:
 
 ```bash
 cat >> .claude/bee-context.local.md << 'CONTEXT_EOF'

--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -45,9 +45,30 @@ If the user gives a vague answer, rephrase and push once. If they hand-wave the 
 
 This isn't adversarial — it's caring enough about the plan to not let weak spots slide. Frame it that way.
 
+### Build context incrementally
+
+After each Q&A pair that resolves a decision or surfaces an important constraint, append it to `.claude/bee-context.local.md`. This keeps a running record that grows richer with every answer — so if context gets compressed in a long session, the file has everything.
+
+**On the first resolved decision**, create the file with a header:
+```bash
+mkdir -p .claude && cat > .claude/bee-context.local.md << 'GRILLME_EOF'
+## Grill-Me Decisions
+
+GRILLME_EOF
+```
+
+**After each subsequent resolved decision**, append:
+```bash
+cat >> .claude/bee-context.local.md << 'GRILLME_EOF'
+- **[Topic]**: [Decision made and rationale]
+GRILLME_EOF
+```
+
+This also means you can re-read the file to remind yourself what's been resolved, which helps you ask sharper follow-ups that connect to earlier answers.
+
 ### Track what's resolved
 
-Mentally keep track of which branches you've explored and which are still open. When you finish a branch, briefly acknowledge it: "OK, I'm clear on how auth works. Moving on to data flow."
+Keep track of which branches you've explored and which are still open. The context file is your running record — use it. When you finish a branch, briefly acknowledge it: "OK, I'm clear on how auth works. Moving on to data flow."
 
 When you've covered everything, say so. Summarize what you now understand, flag anything that still feels shaky, and ask the user if they want to go deeper on any of it.
 
@@ -73,4 +94,12 @@ Stop when:
 - The user says they're satisfied
 - You're going in circles on the same point (acknowledge the disagreement and move on)
 
-End with a brief summary of the plan as you now understand it, including any open items the user chose to defer.
+End with a brief summary of the plan as you now understand it, including any open items the user chose to defer. Append the open items to the context file:
+
+```bash
+cat >> .claude/bee-context.local.md << 'GRILLME_EOF'
+
+### Open Items
+- [Anything the developer chose to defer]
+GRILLME_EOF
+```


### PR DESCRIPTION
## Summary

Incremental updates would be a meaningful improvement. Here's why:

### Current behavior
The grill-me skill runs the entire interview in conversation context, then writes all decisions to `.claude/bee-context.local.md` in a **single shot** after the session concludes (via the SDD orchestrator in `sdd.md` lines ~208-238).

### The problem with one-shot

- The conversation context is the only place decisions live during the interview. If the session is long, earlier Q&A can get compressed/lost from context.
- The griller itself loses track of what's been resolved — it has no persistent "scratch pad" to reference.
- If the session fails or gets interrupted mid-way, all decisions are lost.

### Why incremental updates would help

1. **Richer context during the interview** — After each Q&A, appending to the file means the griller can re-read it to see the full picture so far. This is especially valuable for long sessions where context compression kicks in.
2. **Better questions** — With a running summary of resolved decisions, the griller can ask sharper follow-ups that connect to earlier answers.
3. **Resilience** — If the session is interrupted, you don't lose everything.
4. **Progressive refinement** — The file becomes a living document that gets more detailed with each answer, giving a clearer picture of the feature.

## Test plan

- [ ] Run grill-me on a feature idea and verify `.claude/bee-context.local.md` is created on the first resolved decision
- [ ] Verify each subsequent decision is appended incrementally
- [ ] Verify open items are appended at session end
- [ ] Run `/bee:sdd /grill-me "description"` and verify sdd.md B2.3 correctly detects the pre-built file
- [ ] Verify context-gatherer still appends correctly to the incrementally-built file

🤖 Generated with [Claude Code](https://claude.com/claude-code)