### PR TITLE
Enforce behavioral test naming and block superficial tests

### DIFF
--- a/bee/agents/sdd-verifier.md
+++ b/bee/agents/sdd-verifier.md
@@ -105,6 +105,15 @@ Read each test. Flag weak assertions:
 - Tests that assert on implementation details (mock call counts, exact query strings, internal method calls)
 - Tests that use overly broad matchers (toBeTruthy on complex objects, toEqual on large snapshots without specific checks)
 
+**Superficial test detection (BLOCKING — always fails verification):**
+- Import/existence checks: `expect(X).toBeDefined()`, "should be importable", "module should exist" — if the import is wrong the test file won't compile, so this asserts nothing
+- Constructor-only checks: `expect(new Service()).toBeDefined()` — test what the instance *does*, not that it exists
+- Type-only checks: `expect(typeof result).toBe('object')` — assert on content, not container type
+- No-op assertions: calling a function without asserting on the result
+- Tautological assertions: `expect(true).toBe(true)`
+
+If ANY superficial tests are found, fail the verification with severity BLOCKING and require the slice-tester to rewrite them as behavioral tests.
+
 **2c. Boundary conditions:**
 For functions that validate inputs or have numeric thresholds:
 - Are edge values tested? (0, -1, empty string, null, max int)
@@ -134,11 +143,12 @@ If all ACs are covered: mark the slice checkbox `[x]` in the spec file using Edi
 
 Quick scan of new/modified files:
 - **File naming** — follows project conventions? (kebab-case, PascalCase, whatever the project uses)
+- **Test file naming (BLOCKING)** — test file names must describe behavior, NOT workflow metadata. Flag any test file containing slice numbers, step numbers, or AC references (e.g., `slice-3.2-summarization.test.ts`, `step-1-setup.test.ts`, `ac-2-validation.test.ts`). Test files should be named like `user-authentication.test.ts`, `pricing-discount.test.ts`.
 - **File location** — in the right directory? (tests near source, or in a separate test directory — match existing pattern)
 - **Code style** — consistent with surrounding code? No wildly different formatting or naming
 - **Imports/dependencies** — no unexpected new dependencies? Layer boundaries respected?
 
-This is a quick check, not a style review. Flag only clear violations.
+This is a quick check, not a style review. Flag only clear violations — except test file naming and superficial tests, which are always blocking.
 
 ### Step 5: Risk-Aware Deeper Checks
 

--- a/bee/agents/slice-tester.md
+++ b/bee/agents/slice-tester.md
@@ -117,6 +117,27 @@ Run the project's test command. All tests must pass — both the new ones and al
 - If caused by your testability refactor: revert the refactor, report the issue
 - If pre-existing failure: note it as pre-existing, not caused by this slice
 
+## Test File Naming
+
+Test file names MUST describe the behavior being tested. NEVER use slice numbers, step numbers, or any workflow metadata in file names.
+
+**Good:** `user-authentication.test.ts`, `pricing-discount.test.ts`, `order-validation.test.ts`
+**Bad:** `slice-3.2-summarization.test.ts`, `step-1-setup.test.ts`, `ac-2-validation.test.ts`
+
+Slice numbers are internal planning artifacts — they must not leak into the codebase. Follow the project's existing naming conventions for style.
+
+## Superficial Test Anti-Patterns
+
+The following test patterns are **forbidden** — they verify nothing meaningful:
+
+- **Import/existence checks:** `expect(MyClass).toBeDefined()`, "should be importable", "module should exist". If the import is wrong, the test file won't compile — a separate assertion adds zero value.
+- **Constructor-only checks:** `expect(new Service()).toBeDefined()`, "should create an instance". Test what the instance *does*, not that it exists.
+- **Type-only checks:** `expect(typeof result).toBe('object')`. Assert on the actual content, not the container type.
+- **No-op assertions:** Tests that call a function but never assert on the result. Running code without verifying output proves nothing.
+- **Tautological assertions:** `expect(true).toBe(true)`, `expect(1).toBe(1)`. These always pass and test nothing.
+
+Every test MUST assert on **observable behavior** — what the function returns, what side effects it produces, or what error it throws given specific inputs.
+
 ## What NOT to Do
 
 - **Don't write production code.** You test, you don't build. Small testability refactors are the exception.
@@ -125,6 +146,7 @@ Run the project's test command. All tests must pass — both the new ones and al
 - **Don't over-mock.** If you need 5+ mocks for one test, the code design is wrong. Flag it.
 - **Don't add test utilities or helpers for one test.** Only extract shared setup when 3+ tests use it.
 - **Don't fix bugs in the production code.** Report them. The slice-coder or developer fixes bugs.
+- **Don't write superficial tests.** See anti-patterns above. Every test must verify behavior, not existence.
 
 ## Output
 

--- a/bee/commands/sdd.md
+++ b/bee/commands/sdd.md
@@ -428,7 +428,7 @@ Delegate to the **slice-tester** agent via Task, passing:
 - spec_path: the spec file path
 - slice_number: the current slice number
 - source_files: the files the slice-coder reported creating/modifying
-- test_file_path: the test file path (follow project conventions)
+- test_file_path: the test file path — MUST describe the behavior being tested (e.g., `user-authentication.test.ts`, `pricing-discount.test.ts`, `order-validation.test.ts`). NEVER use slice numbers, step numbers, or any workflow metadata in test file names. Slice numbers are internal planning artifacts — they must not leak into the codebase. Follow existing project naming conventions for style (kebab-case, camelCase, etc.).
 - context_file: `.claude/bee-context.local.md`
 - architecture_file: `.claude/bee-architecture.local.md`
 

--- a/bee/skills/grill-me/SKILL.md
+++ b/bee/skills/grill-me/SKILL.md
@@ -66,6 +66,24 @@ GRILLME_EOF
 
 This also means you can re-read the file to remind yourself what's been resolved, which helps you ask sharper follow-ups that connect to earlier answers.
 
+### When you find a gap — offer to brainstorm
+
+When the user hits a genuine gap — they say "I'm not sure", "I haven't thought about that", give a vague non-answer twice, or explicitly ask "what do you think?" — shift into brainstorming mode to help them resolve it on the spot.
+
+**How to transition:**
+
+Print exactly: `Switching to brainstorm mode to work through this together.`
+
+Then load the `brainstorming` skill using the Skill tool. Run a **focused mini-brainstorm** on the specific gap:
+
+1. Research the topic briefly (WebSearch if useful — load it via ToolSearch first)
+2. Present 2-3 concrete options via AskUserQuestion with a recommendation
+3. Once the user picks a direction, acknowledge the decision and resume grilling
+
+Keep it tight — this is a focused detour, not a full brainstorming session. The goal is to resolve the gap and get back to grilling. If the user wants to go deeper, they can always run `/bee:brainstorm` separately.
+
+**After the mini-brainstorm resolves**, print: `Back to grilling.` and continue from where you left off.
+
 ### Track what's resolved
 
 Keep track of which branches you've explored and which are still open. The context file is your running record — use it. When you finish a branch, briefly acknowledge it: "OK, I'm clear on how auth works. Moving on to data flow."
@@ -94,7 +112,7 @@ Stop when:
 - The user says they're satisfied
 - You're going in circles on the same point (acknowledge the disagreement and move on)
 
-End with a brief summary of the plan as you now understand it, including any open items the user chose to defer. Append the open items to the context file:
+End with a brief summary of the plan as you now understand it, including any open items the user chose to defer. Include decisions that came out of mini-brainstorms — these are now part of the plan. Append the open items to the context file:
 
 ```bash
 cat >> .claude/bee-context.local.md << 'GRILLME_EOF'


### PR DESCRIPTION
## Summary
- **SDD orchestrator**: `test_file_path` now explicitly requires behavior-based naming with examples — slice numbers must never leak into test file names
- **slice-tester**: added test file naming rules and a forbidden superficial anti-patterns list (import checks, `toBeDefined`, constructor-only, type-only, no-op, tautological assertions)
- **sdd-verifier**: superficial tests and slice-numbered test files are now BLOCKING failures that require rewrite before a slice can pass

## Test plan
- [ ] Run `/bee:sdd` on a feature and verify test files are named by behavior (e.g., `user-authentication.test.ts`), not by slice number
- [ ] Verify sdd-verifier blocks slices that contain superficial tests (`toBeDefined`, import checks)
- [ ] Verify slice-tester does not produce import/existence-only assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)