### PR TITLE
Fix brainstorming context loss when invoked within bee:sdd

### DIFF
--- a/bee/commands/brainstorm.md
+++ b/bee/commands/brainstorm.md
@@ -1,7 +1,7 @@
 ---
 description: Start a brainstorming session. Open-ended, collaborative idea generation for product, architecture, UX, or any problem space. Researches online, builds on your ideas, and helps narrow to the best path forward.
 argument-hint: <problem or topic to brainstorm>
-allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash(git:*)", "AskUserQuestion", "Skill", "ToolSearch", "WebSearch", "WebFetch"]
+allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash(git:*)", "Bash(mkdir:*)", "Bash(cat:*)", "AskUserQuestion", "Skill", "ToolSearch", "WebSearch", "WebFetch"]
 ---
 
 **IMPORTANT — Deferred Tool Loading:** Before calling `AskUserQuestion`, `WebSearch`, or `WebFetch`, call `ToolSearch` with query `"select:AskUserQuestion,WebSearch,WebFetch"` to load them. Do this once at the start.
@@ -36,18 +36,10 @@ Follow the brainstorming skill's two-phase process:
 
 ## After the Session
 
-6. Produce the structured brainstorm summary from the skill.
+6. Produce the final brainstorm summary and append it to `.claude/bee-context.local.md` (the skill's incremental writes have been building this file throughout the session — the summary closes it out).
 
-7. If `.claude/bee-context.local.md` exists (running within bee:sdd), append the summary to it:
-   ```bash
-   cat >> .claude/bee-context.local.md << 'BRAIN_EOF'
+7. If standalone (no bee-state), also save the full structured summary to `docs/brainstorms/[topic]-brainstorm.md` (create the directory if needed).
 
-   [brainstorm summary here]
-   BRAIN_EOF
-   ```
-
-8. If standalone (no bee-state), save the summary to `docs/brainstorms/[topic]-brainstorm.md` (create the directory if needed).
-
-9. Offer next steps via AskUserQuestion:
+8. Offer next steps via AskUserQuestion:
    "Nice session! Where to next?"
    Options: "Run /bee:sdd to build this (Recommended)" / "Run /bee:discover to write a PRD" / "Run /bee:brainstorm to explore another angle" / "I'm done for now"

--- a/bee/commands/sdd.md
+++ b/bee/commands/sdd.md
@@ -236,6 +236,28 @@ This way, grill-me decisions + codebase context live in one file and flow to eve
 
 If grill-me was NOT used, skip this step — context-gatherer will create the file from scratch as usual.
 
+### B2.4. Brainstorming Decisions (When Used)
+
+If the developer invoked brainstorming (e.g., `/bee:sdd let's brainstorm "description"` or the brainstorming skill was loaded during this session), the brainstorming skill **builds `.claude/bee-context.local.md` incrementally** — appending each research finding, cross-domain insight, and decision as the session progresses. By the time brainstorming concludes, the file already contains all findings, the chosen direction, and open questions. No post-session capture needed.
+
+**Verify the file exists.** After brainstorming completes, confirm `.claude/bee-context.local.md` exists and has content. If for some reason it doesn't (e.g., brainstorming was run standalone outside SDD), capture the decisions now:
+
+```bash
+mkdir -p .claude && cat > .claude/bee-context.local.md << 'BRAINSTORM_EOF'
+## Brainstorm Decisions
+
+[For each key finding/decision from the brainstorming session:]
+- **[Topic]**: [Decision made and rationale]
+
+### Open Questions
+[Anything deferred or unresolved]
+BRAINSTORM_EOF
+```
+
+When context-gatherer runs later (B3), **append** its output to this file instead of overwriting — same as with grill-me.
+
+If brainstorming was NOT used, skip this step.
+
 ### B2.5. Navigation by Size
 
 After triage and clarification, route by size:

--- a/bee/skills/brainstorming/SKILL.md
+++ b/bee/skills/brainstorming/SKILL.md
@@ -13,6 +13,27 @@ Act as a collaborative brainstorming partner. Generate options, build on ideas, 
 
 Run both phases in every brainstorming session.
 
+### Build context incrementally
+
+After each significant moment — a research finding that changes the direction, a cross-domain insight, or a decision the user makes — append it to `.claude/bee-context.local.md`. This keeps a running record so downstream agents (spec-builder, architecture-advisor, slice-coder) have full context even if the brainstorm ran in an earlier session.
+
+**On the first finding or decision**, create the file with a header:
+```bash
+mkdir -p .claude && cat > .claude/bee-context.local.md << 'BRAINSTORM_EOF'
+## Brainstorm Decisions
+
+BRAINSTORM_EOF
+```
+
+**After each subsequent finding, insight, or decision**, append:
+```bash
+cat >> .claude/bee-context.local.md << 'BRAINSTORM_EOF'
+- **[Topic]**: [What was decided or discovered, and why it matters]
+BRAINSTORM_EOF
+```
+
+If `.claude/bee-context.local.md` already exists (e.g., grill-me ran first, or this is a second brainstorm), always **append** with `>>` — never overwrite.
+
 ### Phase 1: Diverge — Generate Options
 
 Aim for volume and variety. Do not dismiss any idea.
@@ -61,7 +82,22 @@ Present options and give a recommendation, but let the user make the final decis
 
 ## Capturing Decisions
 
-When the session concludes, produce a structured summary:
+Context has been building incrementally throughout the session. At the end, append the final summary to `.claude/bee-context.local.md`:
+
+```bash
+cat >> .claude/bee-context.local.md << 'BRAINSTORM_EOF'
+
+### Brainstorm Summary
+- **Problem**: [One sentence]
+- **Chosen direction**: [Which option and why]
+- **Key insight**: [Most important cross-domain or non-obvious insight]
+
+### Open Questions
+- [Anything deferred or unresolved]
+BRAINSTORM_EOF
+```
+
+When used standalone (via `/bee:brainstorm` with no bee-state), also save the full structured summary to `docs/brainstorms/[topic]-brainstorm.md`:
 
 ```markdown
 ## Brainstorm Summary
@@ -84,8 +120,6 @@ When the session concludes, produce a structured summary:
 ### Open Questions
 - [Anything deferred or unresolved]
 ```
-
-When used within the bee:sdd workflow, append this summary to `.claude/bee-context.local.md` so downstream agents have the full brainstorming context. When used standalone (via `/bee:brainstorm`), save to `docs/brainstorms/[topic]-brainstorm.md`.
 
 ## Tone
 


### PR DESCRIPTION
## Summary
- Brainstorming now writes to `.claude/bee-context.local.md` **incrementally** after each finding, insight, and decision — matching how grill-me already works
- Previously brainstorming only wrote context at session end, which meant downstream agents (spec-builder, architecture-advisor, slice-coder) lost all brainstorm decisions when invoked via `/bee:sdd let's brainstorm "topic"`
- Added `B2.4 Brainstorming Decisions` step to sdd.md so the orchestrator knows to verify and fallback-capture brainstorm context

## Changes
- `bee/skills/brainstorming/SKILL.md` — Added "Build context incrementally" section with bash write patterns, updated "Capturing Decisions" to append final summary
- `bee/commands/brainstorm.md` — Added `Bash(mkdir:*)` and `Bash(cat:*)` to allowed-tools, simplified post-session flow
- `bee/commands/sdd.md` — Added `B2.4` mirroring the existing `B2.3` (grill-me) pattern

## Test plan
- [ ] Run `/bee:sdd let's brainstorm "landing page for PHQ-9"` and verify `.claude/bee-context.local.md` gets entries during the session (not just at the end)
- [ ] Run `/bee:brainstorm` standalone and verify context file is created and `docs/brainstorms/` gets the summary
- [ ] Run `/bee:sdd /grill-me` then brainstorm in the same session — verify context file has both grill-me and brainstorm entries (append, not overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)