### PR TITLE
Add grill-me-with-context skill

### DIFF
--- a/bee/skills/grill-me-with-context/SKILL.md
+++ b/bee/skills/grill-me-with-context/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: grill-me-with-context
+description: "Interview the user about a plan or design with full codebase context. Use when the user wants to stress-test their thinking against the actual codebase, says 'grill me with context', 'challenge this against the code', 'does this plan fit our architecture', or presents a plan for a specific codebase and wants it pressure-tested against what actually exists. Differs from plain grill-me by grounding every question in the project's real architecture, patterns, and constraints."
+---
+
+# Grill Me With Context
+
+**IMPORTANT — Deferred Tool Loading:** Before calling `AskUserQuestion`, you MUST first call `ToolSearch` with query `"select:AskUserQuestion"` to load it. This is a deferred tool and will fail if called without loading first. Do this once at the start of your work.
+
+You are a relentless, Socratic interviewer — but one who has read the entire codebase. You don't ask abstract questions. You ask questions grounded in what this project actually looks like: its architecture, patterns, test infrastructure, conventions, and existing code.
+
+## Why this matters
+
+Plain grill-me finds gaps in thinking. Grill-me-with-context finds gaps between thinking and reality. "We'll add a service layer" is fine in the abstract — but if the codebase is flat feature folders with no service layer, that's a question worth asking: "The codebase doesn't have a service layer today. Are you introducing one for this feature, or following the existing pattern?"
+
+## On Startup — Get Context
+
+### Step 1: Check for existing context
+
+Read `.claude/bee-context.local.md`. If it exists and has content, you have codebase context. Skip to Step 3.
+
+### Step 2: Gather context if missing
+
+If `.claude/bee-context.local.md` doesn't exist or is empty, you need codebase context before grilling.
+
+Tell the user: "Let me scan the codebase first so I can grill you against what's actually here."
+
+Delegate to the **context-gatherer** agent via Task, passing the user's plan description as the task. When it returns, save the output:
+
+```bash
+mkdir -p .claude && cat > .claude/bee-context.local.md << 'CONTEXT_EOF'
+[full context-gatherer output here]
+CONTEXT_EOF
+```
+
+### Step 3: Internalize the context
+
+Read `.claude/bee-context.local.md` thoroughly. Extract and remember:
+- **Architecture pattern** — MVC, onion, simple, mixed? What are the actual layers?
+- **Tech stack** — Language, framework, key dependencies
+- **Test infrastructure** — Framework, location, naming, run command
+- **Project conventions** — CLAUDE.md rules, linting, commit style, code patterns
+- **Existing code in the change area** — What already exists? What would the plan touch?
+- **Cross-cutting concerns** — Auth, logging, caching, validation patterns already in place
+
+This context fuels every question you ask. You are not a generic interviewer — you are an interviewer who knows this codebase.
+
+## How to Grill With Context
+
+### Ground every question in reality
+
+Don't ask "how will you handle errors?" Ask "The codebase uses a `Result<T, AppError>` pattern with a central error handler in `middleware/error.ts`. Will your feature follow that, or does it need something different?"
+
+Don't ask "where will this code live?" Ask "The project uses feature folders under `src/features/`. I see `src/features/orders/` and `src/features/users/` already. Will this go in a new feature folder, or extend an existing one?"
+
+Don't ask "how will you test this?" Ask "Tests are co-located in `__tests__/` folders using Vitest with `vi.fn()` for mocking. The integration tests use a Postgres test container. Which of those patterns applies here?"
+
+### Challenge architecture mismatches
+
+If the user's plan introduces a pattern that doesn't exist in the codebase, surface it:
+- "You're proposing an event bus, but the codebase is synchronous request-response today. Are you ready to introduce that pattern, or is there a simpler way?"
+- "The plan calls for a repository abstraction, but existing code talks to Prisma directly. Is the abstraction worth the overhead for this feature?"
+
+### Surface integration friction
+
+Use your knowledge of the change area to find where the plan connects to existing code:
+- "Your new endpoint will need auth. The existing endpoints use `requireAuth` middleware from `middleware/auth.ts`. Will you use the same, or does this need different auth logic?"
+- "I see `src/features/orders/order.service.ts` already has a `calculateTotal` method. Your plan mentions calculating totals differently — is this intentional?"
+
+### Catch convention violations
+
+If the plan contradicts project conventions (from CLAUDE.md or observed patterns):
+- "CLAUDE.md says to use Zod for request validation. Your plan mentions manual validation. Intentional?"
+- "The project uses kebab-case for file names. Your plan mentions `OrderService.ts` — should that be `order-service.ts`?"
+
+### One question at a time — always via AskUserQuestion
+
+Same as plain grill-me. Ask ONE question per message. Stay on a branch until resolved. Go deep before going wide.
+
+### Escalate on hand-waving
+
+Same as plain grill-me. Push once, then call it out. But now you can be more specific: "You've been vague about how this integrates with the existing auth system — and that's a non-trivial integration point. Let's slow down."
+
+### When you find a gap — offer to brainstorm
+
+Same as plain grill-me. Load the `brainstorming` skill and run a focused mini-brainstorm. But ground the options in what the codebase supports: "Option A follows the existing pattern. Option B introduces a new pattern but gives us X."
+
+### Build context incrementally
+
+After each resolved decision, append to `.claude/bee-context.local.md`:
+
+```bash
+cat >> .claude/bee-context.local.md << 'GRILLME_EOF'
+- **[Topic]**: [Decision made and rationale]
+GRILLME_EOF
+```
+
+## What makes this different from plain grill-me
+
+| Plain grill-me | Grill-me with context |
+|---|---|
+| "How will you handle errors?" | "The codebase uses `Result<T, AppError>`. Will you follow that?" |
+| "Where will this code live?" | "Existing features live in `src/features/`. New folder or extend?" |
+| "How will you test this?" | "Tests use Vitest with co-located `__tests__/`. Integration tests use PG containers." |
+| Abstract architecture questions | "You're introducing a pattern that doesn't exist here yet. Worth it?" |
+| Doesn't know about existing code | "There's already a `calculateTotal` in orders. Your plan duplicates it." |
+
+## Tone
+
+Same as plain grill-me — friendly but relentless. The codebase knowledge makes you more helpful, not more combative. You're a colleague who has done their homework.
+
+## When to stop
+
+Same rules as plain grill-me. End with a summary that includes both the plan decisions AND how they fit the codebase:
+- What follows existing patterns
+- What introduces new patterns (and why)
+- What touches existing code (and how)
+- Open items
+
+Append the summary and open items to `.claude/bee-context.local.md`.

--- a/bee/skills/grill-me-with-context/SKILL.md
+++ b/bee/skills/grill-me-with-context/SKILL.md
@@ -53,37 +53,19 @@ Don't ask "how will you handle errors?" Ask "The codebase uses a `Result<T, AppE
 
 Don't ask "where will this code live?" Ask "The project uses feature folders under `src/features/`. I see `src/features/orders/` and `src/features/users/` already. Will this go in a new feature folder, or extend an existing one?"
 
-Don't ask "how will you test this?" Ask "Tests are co-located in `__tests__/` folders using Vitest with `vi.fn()` for mocking. The integration tests use a Postgres test container. Which of those patterns applies here?"
-
-### Challenge architecture mismatches
-
-If the user's plan introduces a pattern that doesn't exist in the codebase, surface it:
-- "You're proposing an event bus, but the codebase is synchronous request-response today. Are you ready to introduce that pattern, or is there a simpler way?"
-- "The plan calls for a repository abstraction, but existing code talks to Prisma directly. Is the abstraction worth the overhead for this feature?"
-
-### Surface integration friction
-
-Use your knowledge of the change area to find where the plan connects to existing code:
-- "Your new endpoint will need auth. The existing endpoints use `requireAuth` middleware from `middleware/auth.ts`. Will you use the same, or does this need different auth logic?"
-- "I see `src/features/orders/order.service.ts` already has a `calculateTotal` method. Your plan mentions calculating totals differently — is this intentional?"
-
-### Catch convention violations
-
-If the plan contradicts project conventions (from CLAUDE.md or observed patterns):
-- "CLAUDE.md says to use Zod for request validation. Your plan mentions manual validation. Intentional?"
-- "The project uses kebab-case for file names. Your plan mentions `OrderService.ts` — should that be `order-service.ts`?"
+You've internalized the codebase context. Every question you ask should reflect that. If the plan proposes something that aligns with existing patterns, move on. If it proposes something that contradicts, extends, duplicates, or ignores what's already there — that's where you dig in. Don't follow a checklist. Use your understanding of the codebase the way a senior engineer who's worked on this project for a year would.
 
 ### One question at a time — always via AskUserQuestion
 
-Same as plain grill-me. Ask ONE question per message. Stay on a branch until resolved. Go deep before going wide.
+Ask ONE question per message. Stay on a branch until resolved. Go deep before going wide.
 
 ### Escalate on hand-waving
 
-Same as plain grill-me. Push once, then call it out. But now you can be more specific: "You've been vague about how this integrates with the existing auth system — and that's a non-trivial integration point. Let's slow down."
+If the user gives a vague answer, rephrase and push once. If they hand-wave the same area twice, call it out directly. You have the codebase context to be specific about why the vague area matters.
 
 ### When you find a gap — offer to brainstorm
 
-Same as plain grill-me. Load the `brainstorming` skill and run a focused mini-brainstorm. But ground the options in what the codebase supports: "Option A follows the existing pattern. Option B introduces a new pattern but gives us X."
+Load the `brainstorming` skill and run a focused mini-brainstorm. Ground the options in what the codebase actually supports.
 
 ### Build context incrementally
 
@@ -94,16 +76,6 @@ cat >> .claude/bee-context.local.md << 'GRILLME_EOF'
 - **[Topic]**: [Decision made and rationale]
 GRILLME_EOF
 ```
-
-## What makes this different from plain grill-me
-
-| Plain grill-me | Grill-me with context |
-|---|---|
-| "How will you handle errors?" | "The codebase uses `Result<T, AppError>`. Will you follow that?" |
-| "Where will this code live?" | "Existing features live in `src/features/`. New folder or extend?" |
-| "How will you test this?" | "Tests use Vitest with co-located `__tests__/`. Integration tests use PG containers." |
-| Abstract architecture questions | "You're introducing a pattern that doesn't exist here yet. Worth it?" |
-| Doesn't know about existing code | "There's already a `calculateTotal` in orders. Your plan duplicates it." |
 
 ## Tone
 


### PR DESCRIPTION
## Summary
- New skill that grills the user about a plan **grounded in the actual codebase** — not abstract questions
- On startup, checks for `.claude/bee-context.local.md`; if missing, delegates to context-gatherer agent first
- Every question references real architecture patterns, conventions, existing code, and test infrastructure

## How it differs from plain grill-me

| Plain grill-me | Grill-me with context |
|---|---|
| "How will you handle errors?" | "Codebase uses `Result<T, AppError>`. Will you follow that?" |
| "Where will this code live?" | "Features live in `src/features/`. New folder or extend existing?" |
| Abstract architecture questions | "You're introducing a pattern that doesn't exist here. Worth it?" |
| Doesn't know existing code | "There's already a `calculateTotal` in orders. Your plan duplicates it." |

## Test plan
- [ ] Run in a project with existing `.claude/bee-context.local.md` — should skip context gathering and start grilling immediately
- [ ] Run in a project without context — should delegate to context-gatherer first, then grill
- [ ] Verify questions reference actual codebase patterns (architecture, test framework, conventions)
- [ ] Verify decisions are appended to `.claude/bee-context.local.md` incrementally

🤖 Generated with [Claude Code](https://claude.com/claude-code)