### PR TITLE
feat(ccaf): CCAF mock-exam plugin (/ccaf:mock-exam)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,11 @@
       "description": "Learn any technology by building real projects — Claude guides step-by-step, you write every line of code"
     },
     {
+      "name": "ccaf",
+      "source": "./ccaf",
+      "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. /ccaf:mock-exam assembles a 60-question weighted mock (official seed questions + verified generated ones), administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown."
+    },
+    {
       "name": "discovery",
       "source": "./discovery",
       "description": "End-to-end product discovery flow that produces a structured PRD"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/bee-state.local.md
 .claude/bee-insights/
+.claude/ccaf-exam.local.md

--- a/ccaf/.claude-plugin/plugin.json
+++ b/ccaf/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "ccaf",
+  "version": "0.1.0",
+  "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. Assembles a 60-question weighted mock (official seed questions + verified generated ones), administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown. Run /ccaf:mock-exam.",
+  "author": {
+    "name": "Incubyte"
+  },
+  "license": "Proprietary"
+}

--- a/ccaf/CLAUDE.md
+++ b/ccaf/CLAUDE.md
@@ -1,0 +1,21 @@
+# CCAF: Claude Certified Architect – Foundations mock exam
+
+A self-serve readiness gate for the CCAF certification. `/ccaf:mock-exam` administers a faithful
+mock exam and reports a scaled /1000 score with the 720 pass line, so a candidate can check
+readiness before booking the real (paid) exam.
+
+## Layout
+
+- `commands/mock-exam.md` — the `/ccaf:mock-exam` command (loads the engine skill).
+- `skills/ccaf-exam/SKILL.md` — the assemble → administer → score engine.
+- `data/ccaf-blueprint.md` — domains, weights, scenarios, the paraphrased syllabus, scope lists, scoring.
+- `data/ccaf-question-bank.md` — the 12 official sample questions (verbatim), used as seeds + anchors.
+- `scripts/ccaf-exam.sh` — silent state helper (init / get / record / score / clear); never use Write/Edit on the attempt file.
+- `scripts/tests/ccaf-exam.test.sh` — shell test harness for the data files + helper logic.
+
+## Conventions
+
+- Per-attempt state lives at `~/.claude/ccaf-exam.local.md` (user-level, gitignored, never shared).
+- Untimed, honor-system, fully offline. Self-serve: nothing is reported or persisted as history.
+- Scoring: `scaled = 100 + 15 × correct` (linear over the real 100–1000 band); pass = 720 (≥ 42/60).
+- The scaled score is an honest estimate, never presented as Anthropic's proprietary equating curve.

--- a/ccaf/commands/mock-exam.md
+++ b/ccaf/commands/mock-exam.md
@@ -1,0 +1,38 @@
+---
+description: Take a CCAF (Claude Certified Architect – Foundations) mock exam — 60 weighted questions, a scaled /1000 score, and a 720 readiness verdict. Resumable.
+argument-hint: "(no args) — start or resume; 'fresh' — discard any attempt and start new"
+allowed-tools: ["Read", "AskUserQuestion", "Skill", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/ccaf-exam.sh *)"]
+---
+
+## Skill Loading
+
+Load the `ccaf-exam` skill using the Skill tool before doing anything else. It contains the
+full assemble → administer → score engine, the exam-file schema, the scoring rules, and the
+resume/recovery logic.
+
+## What this command does
+
+Administers a faithful **mock** of the Claude Certified Architect – Foundations exam so the
+candidate can self-check readiness before booking the real (paid) exam. It mirrors the real
+format on everything replicable (60 questions, 4 of 6 scenarios, domain weighting
+27/18/20/20/15, single-select MCQ, no penalty for guessing) and reports a scaled 100–1000 score
+with the 720 pass line. The scaled number is an honest estimate — not Anthropic's proprietary
+equating curve.
+
+## Arguments
+
+`$ARGUMENTS`:
+
+- empty — start a new attempt, or offer to resume an in-progress one.
+- `fresh` — discard any existing attempt and assemble a new exam.
+
+## Flow (delegated to the ccaf-exam skill)
+
+1. Check for an existing attempt at `~/.claude/ccaf-exam.local.md` (via `ccaf-exam.sh`).
+2. Resume / start fresh / recover from a damaged file, as the skill describes.
+3. Assemble a 60-question exam (seeds + verified generated questions), or continue an existing one.
+4. Administer 4 questions per screen via AskUserQuestion, saving progress after each screen.
+5. On completion, score and show the scaled /1000 verdict, per-domain breakdown, and disclaimer.
+
+Honor system: untimed, self-serve, nothing shared or reported. The attempt file lives in the
+user's home `~/.claude/` and is never committed.

--- a/ccaf/data/ccaf-blueprint.md
+++ b/ccaf/data/ccaf-blueprint.md
@@ -1,0 +1,328 @@
+# CCAF Mock Exam — Blueprint
+
+Distilled, version-controlled encoding of the **Claude Certified Architect – Foundations (CCAF)**
+exam guide (Anthropic, PBC; guide v0.1, 2025-02-10). This is the read-only authority the
+`/ccaf:mock-exam` command's `ccaf-exam` skill uses to assemble a mock exam. It is **not** shared or
+modified at runtime.
+
+The syllabus below is **paraphrased** from the official guide (an internal NTK document) so this
+repo does not republish it verbatim. The only verbatim content is the 12 official sample questions
+in `ccaf-question-bank.md`, which are the explicit learner-practice anchors. Generated questions
+must test the points below and stay strictly inside the in-scope list.
+
+> The official scaled-scoring curve is proprietary and unpublished. This mock approximates it
+> transparently (see `## Scoring`). Treat a 720+ here as a readiness signal, not a guarantee.
+
+## Exam shape (replicated exactly)
+
+- **60 questions** per attempt.
+- **4 of the 6 scenarios** below, chosen at random per attempt.
+- Each question: single-select, **1 correct option + 3 distractors** (A–D).
+- **No penalty for guessing** — an unanswered question scores as incorrect.
+- Scaled score reported on the **100–1000** band; **pass = 720**; pass/fail designation.
+- Untimed (the real exam is 120 min; this mock does not enforce or report time).
+
+## Target candidate (calibrates difficulty)
+
+A solution architect with ~6+ months hands-on building production systems with Claude: Agent SDK
+(multi-agent orchestration, subagent delegation, tool integration, lifecycle hooks), Claude Code
+team configuration (CLAUDE.md, skills, MCP servers, plan mode), MCP tool/resource design,
+prompt engineering for reliable structured output, context-window management, CI/CD integration,
+and sound escalation/reliability judgment. Questions test **practical tradeoff judgment in
+production**, not trivia or API-parameter memorization.
+
+## Domains and weightings
+
+The 60 questions are distributed by these weights (rounded to sum exactly 60):
+
+| Code | Domain                                     | Weight | Questions / 60 |
+| ---- | ------------------------------------------ | ------ | -------------- |
+| D1   | Agentic Architecture & Orchestration       | 27%    | 16             |
+| D2   | Tool Design & MCP Integration              | 18%    | 11             |
+| D3   | Claude Code Configuration & Workflows      | 20%    | 12             |
+| D4   | Prompt Engineering & Structured Output     | 20%    | 12             |
+| D5   | Context Management & Reliability           | 15%    | 9              |
+
+`16 + 11 + 12 + 12 + 9 = 60`.
+
+## Scenarios (4 of 6 per attempt)
+
+Each question is framed inside a scenario. Pick 4 at random per attempt.
+
+| Slug                     | Scenario                            | Primary domains | Frame |
+| ------------------------ | ----------------------------------- | --------------- | ----- |
+| `customer-support`       | Customer Support Resolution Agent   | D1, D2, D5      | Agent SDK agent handling returns/billing/account issues via MCP tools (get_customer, lookup_order, process_refund, escalate_to_human); target 80%+ first-contact resolution with sound escalation. |
+| `code-generation`        | Code Generation with Claude Code    | D3, D5          | Team using Claude Code for generation/refactor/debug/docs; custom slash commands, CLAUDE.md config, plan mode vs direct. |
+| `multi-agent-research`   | Multi-Agent Research System         | D1, D2, D5      | Coordinator delegates to web-search, document-analysis, synthesis, and report subagents to produce cited reports. |
+| `developer-productivity` | Developer Productivity with Claude  | D2, D3, D1      | Agent SDK tools to explore unfamiliar codebases, understand legacy systems, generate boilerplate; built-in tools + MCP servers. |
+| `claude-code-ci`         | Claude Code for Continuous Integration | D3, D4       | Claude Code in CI/CD: automated reviews, test generation, PR feedback; actionable feedback, minimize false positives. |
+| `structured-extraction`  | Structured Data Extraction          | D4, D5          | Extract from unstructured docs, validate with JSON schemas, high accuracy, graceful edge-case handling, downstream integration. |
+
+---
+
+## Full syllabus (generation guardrails — paraphrased)
+
+Generated questions must test one of these points and be tagged with the domain shown. Each point
+is something the candidate must **know** or be **able to do**. Anti-patterns are flagged because
+the real exam's distractors are built from them.
+
+### D1 — Agentic Architecture & Orchestration
+
+- **D1.1 Agentic loops.** The loop lifecycle: send a request, inspect `stop_reason`
+  (`"tool_use"` → execute the requested tools and iterate; `"end_turn"` → finish). Tool results
+  are appended to conversation history so the model reasons about the next action. Model-driven
+  tool choice vs hard-coded decision trees / fixed tool sequences. Anti-patterns (good distractor
+  fodder): parsing natural-language signals to decide termination; using an arbitrary iteration
+  cap as the primary stop condition; treating the presence of assistant text as "done."
+- **D1.2 Coordinator–subagent orchestration.** Hub-and-spoke: the coordinator owns all
+  inter-subagent communication, error handling, and routing. Subagents run with **isolated
+  context** — they do not inherit the coordinator's history. The coordinator decomposes,
+  delegates, aggregates, and decides which subagents to invoke based on query complexity (don't
+  always run the full pipeline). Risk: too-narrow decomposition → incomplete coverage of broad
+  topics. Partition scope across subagents to avoid duplication; run an iterative-refinement loop
+  (evaluate synthesis for gaps → re-delegate targeted queries → re-synthesize). Route all comms
+  through the coordinator for observability and consistent error handling.
+- **D1.3 Subagent invocation, context passing, spawning.** The `Task` tool spawns subagents and
+  `allowedTools` must include `"Task"`. Context must be provided **explicitly** in the subagent's
+  prompt — no automatic inheritance or shared memory across invocations. `AgentDefinition`
+  configures each subagent's description, system prompt, and tool restrictions. `fork_session`
+  explores divergent approaches from a shared baseline. Pass prior agents' complete findings
+  directly in the prompt; use structured formats to separate content from metadata (source URLs,
+  doc names, page numbers) to preserve attribution. Spawn parallel subagents by emitting multiple
+  `Task` calls in a single response. Coordinator prompts should state goals and quality criteria,
+  not step-by-step procedures (enables subagent adaptability).
+- **D1.4 Multi-step workflows: enforcement & handoff.** Programmatic enforcement (hooks,
+  prerequisite gates) vs prompt-based ordering. When deterministic compliance is required (e.g.
+  verify identity before a financial operation), prompt instructions alone have a non-zero failure
+  rate — use a programmatic prerequisite that blocks downstream tools until earlier steps complete
+  (block `process_refund` until `get_customer` returns a verified ID). Decompose multi-concern
+  requests, investigate each in parallel against shared context, then synthesize one resolution.
+  On mid-process escalation, compile a structured handoff summary (customer ID, root cause, refund
+  amount, recommended action) for a human who lacks the transcript.
+- **D1.5 Agent SDK hooks.** `PostToolUse` hooks intercept and transform tool results before the
+  model processes them (e.g. normalize heterogeneous formats — Unix timestamps, ISO 8601, numeric
+  status codes). Tool-call interception hooks block policy-violating actions (e.g. refunds over a
+  threshold) and redirect to an alternative workflow. Hooks give **deterministic** guarantees;
+  prompts give only probabilistic compliance — choose hooks when business rules must hold.
+- **D1.6 Task decomposition strategies.** Fixed sequential pipelines (prompt chaining) vs dynamic
+  adaptive decomposition driven by intermediate findings. Chaining suits predictable multi-aspect
+  reviews (analyze each file, then a cross-file integration pass). Dynamic decomposition suits
+  open-ended investigation (map structure → identify high-impact areas → prioritized plan that
+  adapts as dependencies surface).
+- **D1.7 Session state, resumption, forking.** `--resume <session-name>` continues a named prior
+  session. `fork_session` creates independent branches from a shared analysis baseline. When
+  resuming after code changes, inform the agent which files changed (targeted re-analysis).
+  Starting fresh with a structured summary is often more reliable than resuming with stale tool
+  results.
+
+### D2 — Tool Design & MCP Integration
+
+- **D2.1 Tool interfaces & descriptions.** Tool descriptions are the **primary** mechanism the LLM
+  uses to select a tool; minimal descriptions cause unreliable selection among similar tools.
+  Include input formats, example queries, edge cases, and when-to-use-vs-alternatives. Ambiguous or
+  overlapping descriptions cause misrouting (`analyze_content` vs `analyze_document`). System-prompt
+  wording can create unintended tool associations. Fixes: rewrite descriptions to differentiate;
+  rename to remove overlap; split a generic tool into purpose-specific tools with defined I/O
+  contracts.
+- **D2.2 Structured error responses.** Use the MCP `isError` flag. Distinguish transient
+  (timeout/unavailable), validation (bad input), business (policy), and permission errors. Generic
+  "Operation failed" prevents recovery decisions. Return structured metadata: `errorCategory`,
+  `isRetryable`, human-readable description; `retriable: false` + customer-friendly explanation for
+  business violations. Subagents recover locally from transient failures and propagate only what
+  they cannot resolve, with partial results and what was attempted. Distinguish an access failure
+  (needs a retry decision) from a valid empty result (a successful query with no matches).
+- **D2.3 Tool distribution & `tool_choice`.** Too many tools (e.g. 18 vs 4–5) degrades selection
+  reliability; agents misuse tools outside their specialization. Scope each agent's tools to its
+  role, with limited cross-role tools for high-frequency needs. Replace generic tools with
+  constrained ones (`fetch_url` → `load_document` that validates URLs). `tool_choice`: `"auto"`
+  (may return text), `"any"` (must call some tool), forced (`{"type":"tool","name":"..."}`). Use
+  forced selection to guarantee a specific tool runs first; `"any"` to guarantee a tool call rather
+  than conversational text.
+- **D2.4 MCP server integration.** Project scope (`.mcp.json`, shared) vs user scope
+  (`~/.claude.json`, personal/experimental). Env-var expansion (`${GITHUB_TOKEN}`) keeps secrets
+  out of committed config. Tools from all configured servers are discovered at connection time and
+  available simultaneously. MCP **resources** expose content catalogs (issue summaries, doc
+  hierarchies, DB schemas) to reduce exploratory tool calls. Enhance MCP tool descriptions so the
+  agent prefers them over built-ins like Grep. Prefer community MCP servers for standard
+  integrations (e.g. Jira); reserve custom servers for team-specific workflows.
+- **D2.5 Built-in tools.** `Grep` for content search; `Glob` for path/name patterns; `Read`/`Write`
+  for full files; `Edit` for targeted unique-match changes (fall back to Read+Write when the anchor
+  text isn't unique). Build understanding incrementally — Grep entry points, then Read to follow
+  imports and trace flows — rather than reading everything upfront. Trace usage across wrapper
+  modules by finding all exported names, then searching each.
+
+### D3 — Claude Code Configuration & Workflows
+
+- **D3.1 CLAUDE.md hierarchy.** User-level (`~/.claude/CLAUDE.md`, **not** shared via VCS),
+  project-level (`.claude/CLAUDE.md` or root), directory-level (subdir CLAUDE.md). `@import` keeps
+  files modular. `.claude/rules/` holds topic-specific rule files instead of one monolith. Diagnose
+  hierarchy issues (a teammate missing instructions because they're in user-level config). Use
+  `/memory` to verify which memory files are loaded.
+- **D3.2 Custom commands & skills.** Project commands in `.claude/commands/` (shared via VCS) vs
+  user commands in `~/.claude/commands/` (personal). Skills in `.claude/skills/` with `SKILL.md`
+  frontmatter: `context: fork` (run in an isolated sub-agent context so verbose/exploratory output
+  doesn't pollute the main conversation), `allowed-tools` (restrict tool access during the skill),
+  `argument-hint`. Personal skill variants live in `~/.claude/skills/`. Choose skills (on-demand,
+  task-specific) vs CLAUDE.md (always-loaded universal standards).
+- **D3.3 Path-specific rules.** `.claude/rules/` files with YAML `paths:` glob frontmatter load
+  only when editing matching files (less irrelevant context, fewer tokens). Glob rules beat
+  directory-level CLAUDE.md for conventions spanning many directories (e.g. `**/*.test.tsx` for
+  test files scattered through the codebase).
+- **D3.4 Plan mode vs direct execution.** Plan mode for complex/large-scale change, multiple valid
+  approaches, architectural decisions, multi-file edits — it enables safe exploration before
+  committing and prevents costly rework. Direct execution for simple, well-scoped changes. The
+  `Explore` subagent isolates verbose discovery and returns summaries to preserve main-conversation
+  context. Combine plan-mode investigation with direct-execution implementation.
+- **D3.5 Iterative refinement.** Concrete input/output examples communicate transformations better
+  than prose. Test-driven iteration: write tests first, then iterate by sharing failures. The
+  interview pattern: have Claude ask questions to surface considerations before implementing. Send
+  all issues in one message when they interact; iterate sequentially when independent.
+- **D3.6 CI/CD integration.** `-p` / `--print` runs Claude Code non-interactively (no input hang).
+  `--output-format json` + `--json-schema` produce machine-parseable findings for inline PR
+  comments. CLAUDE.md supplies project context (testing standards, fixtures, review criteria) to
+  CI-invoked Claude. Session isolation: the session that generated code is less effective at
+  reviewing it than an independent instance. Include prior review findings to avoid duplicate
+  comments; provide existing tests so generation doesn't duplicate coverage.
+
+### D4 — Prompt Engineering & Structured Output
+
+- **D4.1 Explicit criteria for precision.** Explicit categorical criteria beat vague instructions
+  ("flag a comment only when claimed behavior contradicts actual code" vs "check comments are
+  accurate"). "Be conservative" / "only high-confidence" don't actually improve precision. High
+  false-positive categories erode trust in the accurate ones. Define which issues to report vs skip;
+  temporarily disable a high-FP category while you improve it; give explicit severity criteria with
+  concrete code examples.
+- **D4.2 Few-shot prompting.** The most effective lever for consistently formatted, actionable
+  output when instructions alone are inconsistent. Demonstrate ambiguous-case handling; enable
+  generalization to novel patterns; reduce extraction hallucination. Use 2–4 targeted examples that
+  show the reasoning for choosing one action over plausible alternatives; demonstrate the desired
+  output shape; distinguish acceptable patterns from genuine issues; cover varied document
+  structures.
+- **D4.3 Structured output via `tool_use`.** `tool_use` + JSON schema is the most reliable way to
+  guarantee schema-compliant output (eliminates JSON syntax errors). `tool_choice`: `"auto"` (may
+  return text), `"any"` (must call a tool, model picks), forced (a specific named tool). Strict
+  schemas kill **syntax** errors but not **semantic** ones (line items not summing, wrong-field
+  placement). Design required vs optional fields, enums with an `"other"` + detail escape hatch, and
+  **nullable** fields so the model returns null instead of fabricating to satisfy a required field.
+  Add format-normalization rules in the prompt alongside the strict schema.
+- **D4.4 Validation, retry, feedback loops.** Retry-with-error-feedback: append the specific
+  validation errors on retry. Retries are useless when the info is simply **absent** from the source
+  (vs format/structural errors, which retries fix). Track a `detected_pattern` field to analyze
+  false-positive dismissals. Distinguish semantic validation errors from syntax errors (the latter
+  eliminated by tool use). Self-correction flows: extract `calculated_total` alongside
+  `stated_total` to flag discrepancies; add `conflict_detected` booleans for inconsistent sources.
+- **D4.5 Batch processing.** The Message Batches API: ~50% cost savings, up to a 24-hour window,
+  **no latency SLA**. Right for non-blocking, latency-tolerant workloads (overnight reports, weekly
+  audits, nightly test generation); wrong for blocking workflows (pre-merge checks). It does **not**
+  support multi-turn tool calling within a single request. `custom_id` correlates request/response
+  pairs. Match the API to the workload; compute submission frequency from SLA constraints; resubmit
+  only failed docs by `custom_id` (chunk oversized ones); prompt-refine on a sample before bulk.
+- **D4.6 Multi-instance & multi-pass review.** Self-review is limited — a model retains its
+  generation reasoning and is less likely to question its own decisions in the same session.
+  Independent review instances (no prior reasoning context) catch more than self-review or extended
+  thinking. Multi-pass review (per-file local passes + a cross-file integration pass) avoids
+  attention dilution and contradictory findings. Have the model self-report confidence per finding
+  for calibrated review routing.
+
+### D5 — Context Management & Reliability
+
+- **D5.1 Preserving conversation context.** Progressive-summarization risk: vague summaries lose
+  numbers, percentages, dates, and customer-stated expectations. "Lost in the middle": models
+  reliably use the beginning and end of long inputs but may drop the middle. Tool results accumulate
+  tokens disproportionately to relevance (40+ fields when 5 matter). Pass complete history for
+  coherence. Techniques: extract a persistent "case-facts" block (amounts, dates, order numbers,
+  statuses) included in each prompt outside the summary; trim verbose tool outputs to relevant
+  fields; put key findings at the start with explicit section headers; have subagents return
+  structured data (key facts, citations, relevance) instead of verbose reasoning when downstream
+  budgets are tight.
+- **D5.2 Escalation & ambiguity resolution.** Appropriate triggers: explicit human request, policy
+  gaps/exceptions (not merely "complex"), and inability to make progress. Escalate immediately on an
+  explicit demand; otherwise offer to resolve when it's straightforward. Sentiment and self-reported
+  confidence are **unreliable** proxies for case complexity. Multiple customer matches → ask for
+  more identifiers rather than guess. Add explicit escalation criteria with few-shot examples;
+  acknowledge frustration while offering resolution when capable, escalating only if the customer
+  reiterates.
+- **D5.3 Error propagation across agents.** Structured error context (failure type, attempted query,
+  partial results, alternatives) lets the coordinator recover intelligently. Distinguish access
+  failures (need a retry decision) from valid empty results. Generic statuses ("search unavailable")
+  hide context. Anti-patterns: silently suppressing errors (returning empty as success) and
+  terminating the whole workflow on a single failure. Subagents recover locally for transient issues
+  and propagate only the unresolved, with partial results; synthesis output carries coverage
+  annotations (well-supported vs gaps from unavailable sources).
+- **D5.4 Large-codebase context.** Long sessions degrade — the model gives inconsistent answers and
+  cites "typical patterns" instead of the specific classes found earlier. Use scratchpad files to
+  persist key findings across context boundaries; delegate verbose exploration to subagents while
+  the main agent coordinates; export structured agent state/manifests for crash recovery; summarize
+  a phase's findings before spawning the next phase's subagents; use `/compact` when context fills
+  with discovery output.
+- **D5.5 Human review & confidence calibration.** Aggregate accuracy (e.g. 97%) can mask poor
+  performance on specific document types or fields. Use stratified random sampling of
+  high-confidence extractions to measure error rates and spot novel patterns. Calibrate field-level
+  confidence scores against labeled validation sets. Validate accuracy by document type and field
+  before automating high-confidence extractions; route low-confidence or
+  ambiguous/contradictory cases to human review to prioritize limited reviewer capacity.
+- **D5.6 Provenance & uncertainty in multi-source synthesis.** Source attribution is lost during
+  summarization unless claim-source mappings are preserved. Require structured claim-source mappings
+  (source URLs, doc names, excerpts) that downstream agents carry through synthesis. Handle
+  conflicting statistics from credible sources by annotating the conflict with attribution rather
+  than arbitrarily picking one. Require publication/collection dates so temporal differences aren't
+  misread as contradictions. Render content types appropriately (financial → tables, news → prose,
+  technical → structured lists) instead of forcing one uniform format.
+
+## Key concepts & exact identifiers (use precise names in questions)
+
+- **Agent SDK** — `AgentDefinition`; agentic loop; `stop_reason` (`"tool_use"`, `"end_turn"`);
+  hooks (`PostToolUse`, tool-call interception); subagent spawning via the `Task` tool;
+  `allowedTools` (must include `"Task"` to spawn); `fork_session`.
+- **MCP** — servers, tools, resources; `isError`; `errorCategory`, `isRetryable`/`retriable`; tool
+  descriptions & distribution; `.mcp.json` (project) vs `~/.claude.json` (user); env-var expansion.
+- **Claude Code** — CLAUDE.md hierarchy (user/project/dir) + `@import`; `.claude/rules/` with
+  `paths:` glob frontmatter; `.claude/commands/`; `.claude/skills/` `SKILL.md` (`context: fork`,
+  `allowed-tools`, `argument-hint`); plan mode; direct execution; `/memory`; `/compact`;
+  `--resume`; the `Explore` subagent.
+- **Claude Code CLI** — `-p` / `--print`; `--output-format json`; `--json-schema`.
+- **Claude API** — `tool_use` + JSON schema; `tool_choice` (`"auto"`, `"any"`, forced
+  `{"type":"tool","name":"..."}`); `stop_reason`; `max_tokens`; system prompts.
+- **Message Batches API** — ~50% cost; ≤24h window; no SLA; `custom_id`; polling; no multi-turn
+  tool calling.
+- **JSON Schema / Pydantic** — required vs optional; enums; nullable; `"other"` + detail; strict
+  mode (syntax not semantics); validation-retry loops; semantic vs syntax errors.
+- **Other** — built-in tools (Read/Write/Edit/Bash/Grep/Glob); few-shot prompting; prompt chaining;
+  context-window management (progressive summarization, lost-in-the-middle, scratchpads);
+  confidence scoring (field-level, calibration, stratified sampling).
+
+## In-scope topics
+
+Agentic loop implementation; multi-agent orchestration; subagent context management; tool
+interface design; MCP tool/resource design; MCP server config; structured error handling &
+propagation; escalation decision-making; CLAUDE.md config; custom commands & skills; plan mode
+vs direct execution; iterative refinement; structured output via `tool_use`; few-shot prompting;
+batch processing; context-window optimization; human review workflows; information provenance.
+
+## Out-of-scope topics (never generate questions on these)
+
+Fine-tuning / training custom models; API auth / billing / account management; deep
+language/framework implementation beyond tool & schema config; deploying/hosting MCP servers
+(infra, networking, containers); Claude internals / training / weights; Constitutional AI / RLHF
+/ safety training; embeddings / vector DB internals; computer use (browser/desktop);
+vision/image analysis; streaming / SSE implementation; rate limits / quotas / pricing math;
+OAuth / key rotation / auth protocols; specific cloud-provider configs; benchmarking / model
+comparison; prompt-caching internals (beyond "it exists"); tokenization specifics.
+
+## Few-shot anchors
+
+The 12 official sample questions in `ccaf-question-bank.md` are the authoritative style,
+difficulty, and explanation-tone anchors. Generated questions should match their shape:
+a realistic production scenario, one clearly-correct option, and three distractors that a
+candidate with incomplete knowledge might plausibly pick (build distractors from the anti-patterns
+flagged in the syllabus above). Explanations say why the right answer is right **and** why each
+distractor is wrong.
+
+## Scoring
+
+- Raw `correct` = count of questions whose recorded answer equals the answer key
+  (unanswered = incorrect).
+- `scaled = 100 + 15 × correct` (this is `100 + round(correct ÷ 60 × 900)`; since `900 ÷ 60 = 15`
+  exactly, no rounding is needed). Range: 0 correct → 100, 60 correct → 1000.
+- **Pass iff `scaled ≥ 720`**, i.e. **≥ 42 of 60** correct (42 → 730 PASS; 41 → 715 FAIL).
+- Always report a per-domain breakdown (correct / total per D1–D5) and the estimate disclaimer.

--- a/ccaf/data/ccaf-question-bank.md
+++ b/ccaf/data/ccaf-question-bank.md
@@ -1,0 +1,310 @@
+# CCAF Mock Exam — Seed Question Bank
+
+The 12 official sample questions from the CCAF exam guide, transcribed verbatim with their
+official correct answers and explanations. These are **authoritative** (invariant 4.6): never
+rewrite, re-key, or paraphrase. They seed assembled exams as anchors and are also the few-shot
+style reference for generated questions.
+
+Each entry: stable `id`, `source: official`, `domain` (D1–D5), `scenario` slug, `stem`, four
+`options`, the `correct` letter, and the official `explanation`. The assembler may shuffle option
+order at serve time (invariant 4.5); the `correct` letter here refers to the option text, not a
+fixed position.
+
+```yaml
+questions:
+  - id: official-01
+    source: official
+    domain: D1
+    scenario: customer-support
+    stem: >-
+      Production data shows that in 12% of cases, your agent skips get_customer entirely and
+      calls lookup_order using only the customer's stated name, occasionally leading to
+      misidentified accounts and incorrect refunds. What change would most effectively address
+      this reliability issue?
+    options:
+      A: Add a programmatic prerequisite that blocks lookup_order and process_refund calls until get_customer has returned a verified customer ID.
+      B: Enhance the system prompt to state that customer verification via get_customer is mandatory before any order operations.
+      C: Add few-shot examples showing the agent always calling get_customer first, even when customers volunteer order details.
+      D: Implement a routing classifier that analyzes each request and enables only the subset of tools appropriate for that request type.
+    correct: A
+    explanation: >-
+      When a specific tool sequence is required for critical business logic (like verifying
+      customer identity before processing refunds), programmatic enforcement provides
+      deterministic guarantees that prompt-based approaches cannot. Options B and C rely on
+      probabilistic LLM compliance, which is insufficient when errors have financial
+      consequences. Option D addresses tool availability rather than tool ordering, which is not
+      the actual problem.
+
+  - id: official-02
+    source: official
+    domain: D2
+    scenario: customer-support
+    stem: >-
+      Production logs show the agent frequently calls get_customer when users ask about orders
+      (e.g., "check my order #12345"), instead of calling lookup_order. Both tools have minimal
+      descriptions ("Retrieves customer information" / "Retrieves order details") and accept
+      similar identifier formats. What's the most effective first step to improve tool selection
+      reliability?
+    options:
+      A: Add few-shot examples to the system prompt demonstrating correct tool selection patterns, with 5-8 examples showing order-related queries routing to lookup_order.
+      B: Expand each tool's description to include input formats it handles, example queries, edge cases, and boundaries explaining when to use it versus similar tools.
+      C: Implement a routing layer that parses user input before each turn and pre-selects the appropriate tool based on detected keywords and identifier patterns.
+      D: Consolidate both tools into a single lookup_entity tool that accepts any identifier and internally determines which backend to query.
+    correct: B
+    explanation: >-
+      Tool descriptions are the primary mechanism LLMs use for tool selection. When descriptions
+      are minimal, models lack the context to differentiate between similar tools. Option B
+      directly addresses this root cause with a low-effort, high-leverage fix. Few-shot examples
+      (A) add token overhead without fixing the underlying issue. A routing layer (C) is
+      over-engineered and bypasses the LLM's natural language understanding. Consolidating tools
+      (D) is a valid architectural choice but requires more effort than a "first step" warrants
+      when the immediate problem is inadequate descriptions.
+
+  - id: official-03
+    source: official
+    domain: D5
+    scenario: customer-support
+    stem: >-
+      Your agent achieves 55% first-contact resolution, well below the 80% target. Logs show it
+      escalates straightforward cases (standard damage replacements with photo evidence) while
+      attempting to autonomously handle complex situations requiring policy exceptions. What's
+      the most effective way to improve escalation calibration?
+    options:
+      A: Add explicit escalation criteria to your system prompt with few-shot examples demonstrating when to escalate versus resolve autonomously.
+      B: Have the agent self-report a confidence score (1-10) before each response and automatically route requests to humans when confidence falls below a threshold.
+      C: Deploy a separate classifier model trained on historical tickets to predict which requests need escalation before the main agent begins processing.
+      D: Implement sentiment analysis to detect customer frustration levels and automatically escalate when negative sentiment exceeds a threshold.
+    correct: A
+    explanation: >-
+      Adding explicit escalation criteria with few-shot examples directly addresses the root
+      cause: unclear decision boundaries. This is the proportionate first response before adding
+      infrastructure. Option B fails because LLM self-reported confidence is poorly calibrated —
+      the agent is already incorrectly confident on hard cases. Option C is over-engineered,
+      requiring labeled data and ML infrastructure when prompt optimization hasn't been tried.
+      Option D solves a different problem entirely; sentiment doesn't correlate with case
+      complexity, which is the actual issue.
+
+  - id: official-04
+    source: official
+    domain: D3
+    scenario: code-generation
+    stem: >-
+      You want to create a custom /review slash command that runs your team's standard code
+      review checklist. This command should be available to every developer when they clone or
+      pull the repository. Where should you create this command file?
+    options:
+      A: In the .claude/commands/ directory in the project repository
+      B: In ~/.claude/commands/ in each developer's home directory
+      C: In the CLAUDE.md file at the project root
+      D: In a .claude/config.json file with a commands array
+    correct: A
+    explanation: >-
+      Project-scoped custom slash commands should be stored in the .claude/commands/ directory
+      within the repository. These commands are version-controlled and automatically available to
+      all developers when they clone or pull the repo. Option B (~/.claude/commands/) is for
+      personal commands that aren't shared via version control. Option C (CLAUDE.md) is for
+      project instructions and context, not command definitions. Option D describes a
+      configuration mechanism that doesn't exist in Claude Code.
+
+  - id: official-05
+    source: official
+    domain: D3
+    scenario: code-generation
+    stem: >-
+      You've been assigned to restructure the team's monolithic application into microservices.
+      This will involve changes across dozens of files and requires decisions about service
+      boundaries and module dependencies. Which approach should you take?
+    options:
+      A: Enter plan mode to explore the codebase, understand dependencies, and design an implementation approach before making changes.
+      B: Start with direct execution and make changes incrementally, letting the implementation reveal the natural service boundaries.
+      C: Use direct execution with comprehensive upfront instructions detailing exactly how each service should be structured.
+      D: Begin in direct execution mode and only switch to plan mode if you encounter unexpected complexity during implementation.
+    correct: A
+    explanation: >-
+      Plan mode is designed for complex tasks involving large-scale changes, multiple valid
+      approaches, and architectural decisions — exactly what monolith-to-microservices
+      restructuring requires. It enables safe codebase exploration and design before committing
+      to changes. Option B risks costly rework when dependencies are discovered late. Option C
+      assumes you already know the right structure without exploring the code. Option D ignores
+      that the complexity is already stated in the requirements, not something that might emerge
+      later.
+
+  - id: official-06
+    source: official
+    domain: D3
+    scenario: code-generation
+    stem: >-
+      Your codebase has distinct areas with different coding conventions: React components use
+      functional style with hooks, API handlers use async/await with specific error handling, and
+      database models follow a repository pattern. Test files are spread throughout the codebase
+      alongside the code they test (e.g., Button.test.tsx next to Button.tsx), and you want all
+      tests to follow the same conventions regardless of location. What's the most maintainable
+      way to ensure Claude automatically applies the correct conventions when generating code?
+    options:
+      A: Create rule files in .claude/rules/ with YAML frontmatter specifying glob patterns to conditionally apply conventions based on file paths
+      B: Consolidate all conventions in the root CLAUDE.md file under headers for each area, relying on Claude to infer which section applies
+      C: Create skills in .claude/skills/ for each code type that include the relevant conventions in their SKILL.md files
+      D: Place a separate CLAUDE.md file in each subdirectory containing that area's specific conventions
+    correct: A
+    explanation: >-
+      Option A is correct because .claude/rules/ with glob patterns (e.g., **/*.test.tsx) allows
+      conventions to be automatically applied based on file paths regardless of directory
+      location — essential for test files spread throughout the codebase. Option B relies on
+      inference rather than explicit matching, making it unreliable. Option C requires manual
+      skill invocation or relies on Claude choosing to load them, contradicting the need for
+      deterministic "automatic" application based on file paths. Option D can't easily handle
+      files spread across many directories since CLAUDE.md files are directory-bound.
+
+  - id: official-07
+    source: official
+    domain: D1
+    scenario: multi-agent-research
+    stem: >-
+      After running the system on the topic "impact of AI on creative industries," you observe
+      that each subagent completes successfully, but the final reports cover only visual arts,
+      completely missing music, writing, and film production. The coordinator's logs show it
+      decomposed the topic into "AI in digital art creation," "AI in graphic design," and "AI in
+      photography." What is the most likely root cause?
+    options:
+      A: The synthesis agent lacks instructions for identifying coverage gaps in the findings it receives from other agents.
+      B: The coordinator agent's task decomposition is too narrow, resulting in subagent assignments that don't cover all relevant domains of the topic.
+      C: The web search agent's queries are not comprehensive enough and need to be expanded to cover more creative industry sectors.
+      D: The document analysis agent is filtering out sources related to non-visual creative industries due to overly restrictive relevance criteria.
+    correct: B
+    explanation: >-
+      The coordinator's logs reveal the root cause directly: it decomposed "creative industries"
+      into only visual arts subtasks (digital art, graphic design, photography), completely
+      omitting music, writing, and film. The subagents executed their assigned tasks correctly —
+      the problem is what they were assigned. Options A, C, and D incorrectly blame downstream
+      agents that are working correctly within their assigned scope.
+
+  - id: official-08
+    source: official
+    domain: D5
+    scenario: multi-agent-research
+    stem: >-
+      The web search subagent times out while researching a complex topic. You need to design how
+      this failure information flows back to the coordinator agent. Which error propagation
+      approach best enables intelligent recovery?
+    options:
+      A: Return structured error context to the coordinator including the failure type, the attempted query, any partial results, and potential alternative approaches.
+      B: Implement automatic retry logic with exponential backoff within the subagent, returning a generic "search unavailable" status only after all retries are exhausted.
+      C: Catch the timeout within the subagent and return an empty result set marked as successful.
+      D: Propagate the timeout exception directly to a top-level handler that terminates the entire research workflow.
+    correct: A
+    explanation: >-
+      Structured error context gives the coordinator the information it needs to make intelligent
+      recovery decisions — whether to retry with a modified query, try an alternative approach, or
+      proceed with partial results. Option B's generic status hides valuable context from the
+      coordinator, preventing informed decisions. Option C suppresses the error by marking failure
+      as success, which prevents any recovery and risks incomplete research outputs. Option D
+      terminates the entire workflow unnecessarily when recovery strategies could succeed.
+
+  - id: official-09
+    source: official
+    domain: D2
+    scenario: multi-agent-research
+    stem: >-
+      The synthesis agent frequently needs to verify specific claims while combining findings.
+      Currently it returns control to the coordinator, which invokes the web search agent, then
+      re-invokes synthesis — adding 2-3 round trips and 40% latency. 85% of these verifications
+      are simple fact-checks (dates, names, statistics) while 15% require deeper investigation.
+      What's the most effective approach to reduce overhead while maintaining reliability?
+    options:
+      A: Give the synthesis agent a scoped verify_fact tool for simple lookups, while complex verifications continue delegating to the web search agent through the coordinator.
+      B: Have the synthesis agent accumulate all verification needs and return them as a batch to the coordinator at the end of its pass, which then sends them all to the web search agent at once.
+      C: Give the synthesis agent access to all web search tools so it can handle any verification need directly without round-trips through the coordinator.
+      D: Have the web search agent proactively cache extra context around each source during initial research, anticipating what the synthesis agent might need to verify.
+    correct: A
+    explanation: >-
+      Option A applies the principle of least privilege by giving the synthesis agent only what it
+      needs for the 85% common case (simple fact verification) while preserving the existing
+      coordination pattern for complex cases. Option B's batching approach creates blocking
+      dependencies since synthesis steps may depend on earlier verified facts. Option C
+      over-provisions the synthesis agent, violating separation of concerns. Option D relies on
+      speculative caching that cannot reliably predict what the synthesis agent will need to
+      verify.
+
+  - id: official-10
+    source: official
+    domain: D3
+    scenario: claude-code-ci
+    stem: >-
+      Your pipeline script runs `claude "Analyze this pull request for security issues"` but the
+      job hangs indefinitely. Logs indicate Claude Code is waiting for interactive input. What's
+      the correct approach to run Claude Code in an automated pipeline?
+    options:
+      A: Add the -p flag: claude -p "Analyze this pull request for security issues"
+      B: Set the environment variable CLAUDE_HEADLESS=true before running the command
+      C: Redirect stdin from /dev/null
+      D: Add the --batch flag: claude --batch "Analyze this pull request for security issues"
+    correct: A
+    explanation: >-
+      The -p (or --print) flag is the documented way to run Claude Code in non-interactive mode.
+      It processes the prompt, outputs the result to stdout, and exits without waiting for user
+      input — exactly what CI/CD pipelines require. The other options reference non-existent
+      features (CLAUDE_HEADLESS environment variable, --batch flag) or use Unix workarounds that
+      don't properly address Claude Code's command syntax.
+
+  - id: official-11
+    source: official
+    domain: D4
+    scenario: claude-code-ci
+    stem: >-
+      Currently real-time Claude calls power two workflows: (1) a blocking pre-merge check that
+      must complete before developers can merge, and (2) a technical debt report generated
+      overnight. Your manager proposes switching both to the Message Batches API for its 50% cost
+      savings. How should you evaluate this proposal?
+    options:
+      A: Use batch processing for the technical debt reports only; keep real-time calls for pre-merge checks.
+      B: Switch both workflows to batch processing with status polling to check for completion.
+      C: Keep real-time calls for both workflows to avoid batch result ordering issues.
+      D: Switch both to batch processing with a timeout fallback to real-time if batches take too long.
+    correct: A
+    explanation: >-
+      The Message Batches API offers 50% cost savings but has processing times up to 24 hours with
+      no guaranteed latency SLA. This makes it unsuitable for blocking pre-merge checks where
+      developers wait for results, but ideal for overnight batch jobs like technical debt reports.
+      Option B is wrong because relying on "often faster" completion isn't acceptable for blocking
+      workflows. Option C reflects a misconception — batch results can be correlated using
+      custom_id fields. Option D adds unnecessary complexity when the simpler solution is matching
+      each API to its appropriate use case.
+
+  - id: official-12
+    source: official
+    domain: D4
+    scenario: claude-code-ci
+    stem: >-
+      A pull request modifies 14 files. Your single-pass review analyzing all files together
+      produces inconsistent results: detailed feedback for some files but superficial comments for
+      others, obvious bugs missed, and contradictory feedback — flagging a pattern as problematic
+      in one file while approving identical code elsewhere in the same PR. How should you
+      restructure the review?
+    options:
+      A: Split into focused passes: analyze each file individually for local issues, then run a separate integration-focused pass examining cross-file data flow.
+      B: Require developers to split large PRs into smaller submissions of 3-4 files before the automated review runs.
+      C: Switch to a higher-tier model with a larger context window to give all 14 files adequate attention in one pass.
+      D: Run three independent review passes on the full PR and only flag issues that appear in at least two of the three runs.
+    correct: A
+    explanation: >-
+      Splitting reviews into focused passes directly addresses the root cause: attention dilution
+      when processing many files at once. File-by-file analysis ensures consistent depth, while a
+      separate integration pass catches cross-file issues. Option B shifts burden to developers
+      without improving the system. Option C misunderstands that larger context windows don't
+      solve attention quality issues. Option D would actually suppress detection of real bugs by
+      requiring consensus on issues that may only be caught intermittently.
+```
+
+## Domain coverage of the seed bank
+
+| Domain | Seed questions |
+| ------ | -------------- |
+| D1     | official-01, official-07 |
+| D2     | official-02, official-09 |
+| D3     | official-04, official-05, official-06, official-10 |
+| D4     | official-11, official-12 |
+| D5     | official-03, official-08 |
+
+Scenarios covered by seeds: `customer-support`, `code-generation`, `multi-agent-research`,
+`claude-code-ci` (4 of 6). The two uncovered scenarios — `developer-productivity`,
+`structured-extraction` — are filled entirely by generated questions when selected.

--- a/ccaf/scripts/ccaf-exam.sh
+++ b/ccaf/scripts/ccaf-exam.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# ccaf-exam.sh — Silent state persistence for the /ccaf:mock-exam mock exam.
+#
+# Called via Bash from the ccaf-exam skill to avoid Write/Edit permission prompts.
+# Operates on a single per-attempt file (default ~/.claude/ccaf-exam.local.md;
+# override with CCAF_EXAM_FILE, used by tests).
+#
+# Usage:
+#   ccaf-exam.sh init                 # read full exam body from stdin, write the file
+#   ccaf-exam.sh get                  # print the whole file
+#   ccaf-exam.sh get --field status   # print one frontmatter field (status|next_index|total)
+#   ccaf-exam.sh record --q 7 --answer C   # record an answer, advance next_index
+#   ccaf-exam.sh score                # tally + scaled score + per-domain; mark completed
+#   ccaf-exam.sh clear                # remove the file
+#
+# Exam file format (frontmatter + one block per question):
+#   ---
+#   status: in_progress            # in_progress | completed
+#   total: 60
+#   scenarios: a,b,c,d
+#   next_index: 1
+#   ---
+#   [[Q1]]
+#   domain: D1
+#   scenario: customer-support
+#   source: official
+#   id: official-01
+#   stem: ...
+#   A) ...
+#   B) ...
+#   C) ...
+#   D) ...
+#   answer_key: A
+#   user_answer:
+#   [[Q2]]
+#   ...
+#
+# The script only reads/writes the frontmatter fields and each block's
+# `domain:`, `answer_key:`, and `user_answer:` lines. Everything else is opaque.
+
+EXAM_FILE="${CCAF_EXAM_FILE:-$HOME/.claude/ccaf-exam.local.md}"
+
+die() { echo "ccaf-exam: $*" >&2; exit 1; }
+
+require_file() {
+  [[ -f "$EXAM_FILE" ]] || die "no active exam at $EXAM_FILE"
+}
+
+read_field() {
+  # Reads a frontmatter field from the first --- block.
+  local key="$1"
+  awk -v k="$key" '
+    /^---$/ { fm++; next }
+    fm == 1 && $0 ~ "^" k ":" {
+      sub("^" k ":[[:space:]]*", "")
+      print
+      exit
+    }
+  ' "$EXAM_FILE"
+}
+
+set_field() {
+  # Replaces a frontmatter field value in place (first --- block).
+  local key="$1" value="$2" tmp
+  tmp="$(mktemp)"
+  awk -v k="$key" -v v="$value" '
+    /^---$/ { fm++ }
+    fm == 1 && $0 ~ "^" k ":" { print k ": " v; next }
+    { print }
+  ' "$EXAM_FILE" > "$tmp"
+  mv "$tmp" "$EXAM_FILE"
+}
+
+recompute_next_index() {
+  # next_index = lowest question number with an empty user_answer, else total+1.
+  local total next
+  total="$(read_field total)"
+  next="$(awk '
+    /^\[\[Q[0-9]+\]\]$/ {
+      qn = $0; gsub(/[^0-9]/, "", qn); cur = qn + 0; ua = ""
+    }
+    /^user_answer:/ {
+      val = $0; sub(/^user_answer:[[:space:]]*/, "", val)
+      if (val == "" && cur > 0 && (found == 0 || cur < found)) found = cur
+    }
+    END { print (found ? found : 0) }
+  ' "$EXAM_FILE")"
+  if [[ "$next" -eq 0 ]]; then
+    next=$(( total + 1 ))
+  fi
+  set_field next_index "$next"
+}
+
+cmd_init() {
+  mkdir -p "$(dirname "$EXAM_FILE")"
+  cat > "$EXAM_FILE"   # body from stdin
+  echo "Exam written to $EXAM_FILE"
+}
+
+cmd_get() {
+  require_file
+  if [[ "${1:-}" == "--field" ]]; then
+    [[ -n "${2:-}" ]] || die "get --field needs a field name"
+    read_field "$2"
+  else
+    cat "$EXAM_FILE"
+  fi
+}
+
+cmd_record() {
+  require_file
+  local q="" answer=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --q)      q="$2";      shift 2 ;;
+      --answer) answer="$2"; shift 2 ;;
+      *) die "record: unknown flag $1" ;;
+    esac
+  done
+  [[ "$q" =~ ^[0-9]+$ ]] || die "record: --q must be a question number"
+  [[ "$answer" =~ ^[A-D]$ ]] || die "record: --answer must be one of A B C D"
+
+  local tmp
+  tmp="$(mktemp)"
+  awk -v target="$q" -v ans="$answer" '
+    /^\[\[Q[0-9]+\]\]$/ {
+      qn = $0; gsub(/[^0-9]/, "", qn); cur = qn + 0
+    }
+    /^user_answer:/ && cur == target { print "user_answer: " ans; done=1; next }
+    { print }
+    END { if (!done) exit 3 }
+  ' "$EXAM_FILE" > "$tmp" || die "record: question $q not found"
+  mv "$tmp" "$EXAM_FILE"
+  recompute_next_index
+  echo "Recorded Q$q=$answer; next_index=$(read_field next_index)"
+}
+
+cmd_score() {
+  require_file
+  awk '
+    BEGIN { total = 0; correct = 0 }
+    /^\[\[Q[0-9]+\]\]$/ { domain=""; key=""; ua=""; inblock=1; next }
+    inblock && /^domain:/      { domain=$0; sub(/^domain:[[:space:]]*/, "", domain) }
+    inblock && /^answer_key:/  { key=$0;    sub(/^answer_key:[[:space:]]*/, "", key) }
+    inblock && /^user_answer:/ {
+      ua=$0; sub(/^user_answer:[[:space:]]*/, "", ua)
+      # end of a question block (user_answer is the last field per block)
+      total++
+      dtotal[domain]++
+      if (ua != "" && ua == key) { correct++; dcorrect[domain]++ }
+      inblock=0
+    }
+    END {
+      # scaled = 100 + round(correct/total * 900). For the production 60-question
+      # exam this is exactly 100 + 15*correct (since 900/60 = 15).
+      scaled = (total > 0) ? 100 + int(correct * 900 / total + 0.5) : 100
+      verdict = (scaled >= 720) ? "PASS" : "FAIL"
+      printf "correct=%d/%d\n", correct, total
+      printf "scaled=%d\n", scaled
+      printf "verdict=%s\n", verdict
+      n = split("D1,D2,D3,D4,D5", doms, ",")
+      for (i = 1; i <= n; i++) {
+        d = doms[i]
+        printf "domain=%s correct=%d total=%d\n", d, dcorrect[d]+0, dtotal[d]+0
+      }
+    }
+  ' "$EXAM_FILE"
+  set_field status completed
+}
+
+cmd_clear() {
+  rm -f "$EXAM_FILE"
+  echo "Exam cleared."
+}
+
+[[ $# -ge 1 ]] || die "usage: ccaf-exam.sh {init|get|record|score|clear} [...]"
+command="$1"; shift
+case "$command" in
+  init)   cmd_init "$@" ;;
+  get)    cmd_get "$@" ;;
+  record) cmd_record "$@" ;;
+  score)  cmd_score "$@" ;;
+  clear)  cmd_clear "$@" ;;
+  *) die "unknown command: $command" ;;
+esac

--- a/ccaf/scripts/tests/ccaf-exam.test.sh
+++ b/ccaf/scripts/tests/ccaf-exam.test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Tests for the /ccaf:mock-exam mock-exam build:
+#  - data files (slice 5.1): blueprint + seed bank structure
+#  - ccaf-exam.sh state helper (slices 5.2-5.6): init/get/record/score/clear,
+#    next_index advancement (resume), and the scaled-score math.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DATA_DIR="$(cd "$SCRIPTS_DIR/../data" && pwd)"
+HELPER="$SCRIPTS_DIR/ccaf-exam.sh"
+BLUEPRINT="$DATA_DIR/ccaf-blueprint.md"
+BANK="$DATA_DIR/ccaf-question-bank.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WORK=""
+
+setup() { WORK="$(mktemp -d)"; export CCAF_EXAM_FILE="$WORK/ccaf-exam.local.md"; }
+teardown() { [[ -n "$WORK" && -d "$WORK" ]] && rm -rf "$WORK"; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "  FAIL: $label (expected '$expected', got '$actual')"; FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [[ -f "$path" ]]; then echo "  PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
+  else echo "  FAIL: $label (not found: $path)"; FAIL_COUNT=$((FAIL_COUNT + 1)); fi
+}
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then echo "  PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
+  else echo "  FAIL: $label (missing '$needle')"; FAIL_COUNT=$((FAIL_COUNT + 1)); fi
+}
+
+# --- Builds a synthetic exam file: N questions, first M answered correctly. ---
+# Domains cycle D1..D5; answer_key = A for all; user_answer = A for the first M.
+make_exam() {
+  local n="$1" m_correct="$2" status="${3:-in_progress}"
+  { echo "---"; echo "status: $status"; echo "total: $n"
+    echo "scenarios: customer-support,code-generation,multi-agent-research,claude-code-ci"
+    echo "next_index: 1"; echo "---"
+    local i ua dom
+    for ((i = 1; i <= n; i++)); do
+      dom="D$(( (i - 1) % 5 + 1 ))"
+      if (( i <= m_correct )); then ua="A"; else ua=""; fi
+      echo "[[Q$i]]"; echo "domain: $dom"; echo "scenario: code-generation"
+      echo "source: generated"; echo "stem: question $i"
+      echo "A) a"; echo "B) b"; echo "C) c"; echo "D) d"
+      echo "answer_key: A"; echo "user_answer: $ua"
+    done
+  } | bash "$HELPER" init >/dev/null
+}
+
+field() { bash "$HELPER" get --field "$1"; }
+score_field() { bash "$HELPER" score | grep -m1 "^$1=" | sed "s/^$1=//"; }
+
+echo "== Slice 5.1: data files =="
+assert_file_exists "blueprint exists" "$BLUEPRINT"
+assert_file_exists "question bank exists" "$BANK"
+assert_eq "12 seed questions"            "12" "$(grep -c '^  - id:' "$BANK")"
+assert_eq "12 correct keys"              "12" "$(grep -cE '^    correct: [A-D]$' "$BANK")"
+assert_eq "12 source: official tags"     "12" "$(grep -cE '^    source: official$' "$BANK")"
+assert_eq "12 domain tags"               "12" "$(grep -cE '^    domain: D[1-5]$' "$BANK")"
+assert_eq "12 scenario tags"             "12" "$(grep -cE '^    scenario: [a-z-]+$' "$BANK")"
+# Domain weights in the blueprint sum to 60.
+WEIGHTSUM="$(grep -oE '\| [0-9]+ +\|$' "$BLUEPRINT" | grep -oE '[0-9]+' | awk '{s+=$1} END{print s}')"
+assert_eq "domain weights sum to 60"     "60" "$WEIGHTSUM"
+assert_contains "blueprint names 720 pass" "$(cat "$BLUEPRINT")" "pass = 720"
+assert_contains "blueprint has out-of-scope list" "$(cat "$BLUEPRINT")" "Out-of-scope topics"
+
+echo "== Slice 5.2: init + get =="
+setup
+make_exam 4 0
+assert_file_exists "exam file written" "$CCAF_EXAM_FILE"
+assert_eq "status in_progress"  "in_progress" "$(field status)"
+assert_eq "total persisted"     "4"           "$(field total)"
+assert_eq "next_index starts 1" "1"           "$(field next_index)"
+teardown
+
+echo "== Slice 5.3 + 5.5: record advances next_index (resume cursor) =="
+setup
+make_exam 4 0
+bash "$HELPER" record --q 1 --answer A >/dev/null
+assert_eq "after Q1, next_index=2" "2" "$(field next_index)"
+bash "$HELPER" record --q 2 --answer B >/dev/null
+assert_eq "after Q2, next_index=3" "3" "$(field next_index)"
+# Answer out of order: Q4 then next_index still points at the first gap (Q3).
+bash "$HELPER" record --q 4 --answer C >/dev/null
+assert_eq "gap at Q3 -> next_index=3" "3" "$(field next_index)"
+bash "$HELPER" record --q 3 --answer D >/dev/null
+assert_eq "all answered -> next_index=total+1" "5" "$(field next_index)"
+teardown
+
+echo "== Slice 5.4: scoring math =="
+setup; make_exam 60 60
+assert_eq "60/60 -> scaled 1000" "1000" "$(score_field scaled)"
+assert_eq "60/60 -> PASS"        "PASS" "$(score_field verdict)"
+teardown
+setup; make_exam 60 0
+assert_eq "0/60 -> scaled 100"   "100"  "$(score_field scaled)"
+assert_eq "0/60 -> FAIL"         "FAIL" "$(score_field verdict)"
+teardown
+setup; make_exam 60 42
+assert_eq "42/60 -> scaled 730 (boundary)" "730"  "$(score_field scaled)"
+assert_eq "42/60 -> PASS"                  "PASS" "$(score_field verdict)"
+teardown
+setup; make_exam 60 41
+assert_eq "41/60 -> scaled 715 (just under)" "715"  "$(score_field scaled)"
+assert_eq "41/60 -> FAIL"                    "FAIL" "$(score_field verdict)"
+teardown
+
+echo "== Slice 5.4: unanswered counts as incorrect =="
+setup; make_exam 10 0   # all blank
+# answer 5 correctly; 5 remain blank -> correct=5
+for q in 1 2 3 4 5; do bash "$HELPER" record --q "$q" --answer A >/dev/null; done
+assert_eq "5 answered, 5 blank -> correct=5/10" "correct=5/10" "$(bash "$HELPER" score | grep -m1 '^correct=')"
+teardown
+
+echo "== Slice 5.4: per-domain breakdown =="
+setup; make_exam 10 10   # domains cycle D1..D5 -> each domain has 2 questions, all correct
+assert_contains "D1 2/2" "$(bash "$HELPER" score)" "domain=D1 correct=2 total=2"
+assert_contains "D5 2/2" "$(bash "$HELPER" score)" "domain=D5 correct=2 total=2"
+teardown
+
+echo "== Slice 5.4: score marks completed =="
+setup; make_exam 4 4
+bash "$HELPER" score >/dev/null
+assert_eq "status -> completed" "completed" "$(field status)"
+teardown
+
+echo "== Slice 5.6: clear removes the file =="
+setup; make_exam 4 0
+bash "$HELPER" clear >/dev/null
+if [[ -f "$CCAF_EXAM_FILE" ]]; then
+  echo "  FAIL: clear removed file"; FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+  echo "  PASS: clear removed file"; PASS_COUNT=$((PASS_COUNT + 1))
+fi
+teardown
+
+echo "== Slice 5.6: get on missing file fails gracefully =="
+setup
+if bash "$HELPER" get >/dev/null 2>&1; then
+  echo "  FAIL: get should fail when no exam exists"; FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+  echo "  PASS: get fails cleanly when no exam exists"; PASS_COUNT=$((PASS_COUNT + 1))
+fi
+teardown
+
+echo ""
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+[[ "$FAIL_COUNT" -eq 0 ]]

--- a/ccaf/skills/ccaf-exam/SKILL.md
+++ b/ccaf/skills/ccaf-exam/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ccaf-exam
+description: "Engine for the /ccaf:mock-exam mock exam. Assembles a 60-question CCAF mock (official seed questions + verified generated ones), administers it 4 questions per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line. Use when running or resuming /ccaf:mock-exam."
+---
+
+# CCAF Mock Exam Engine
+
+You administer a faithful **mock** of the Claude Certified Architect – Foundations (CCAF) exam.
+Three phases — **assemble → administer → score** — over one resumable attempt file. Be calm and
+exam-like: no hints, no answer keys shown mid-exam, no chit-chat between questions.
+
+All state lives in `~/.claude/ccaf-exam.local.md`, written **only** through the pre-approved
+helper so there are no permission prompts:
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/ccaf-exam.sh" <init|get|record|score|clear> [...]
+```
+
+Read-only authority: `${CLAUDE_PLUGIN_ROOT}/data/ccaf-blueprint.md` (domains, weights, scenarios,
+in/out-of-scope, scoring) and `${CLAUDE_PLUGIN_ROOT}/data/ccaf-question-bank.md` (the 12 official
+seed questions). Read both before assembling.
+
+## On startup — resume / fresh / recover
+
+1. If `$ARGUMENTS` is `fresh`: run `ccaf-exam.sh clear`, then go to **Assemble**.
+2. Otherwise read the current status: `ccaf-exam.sh get --field status`.
+   - **Command fails / no file** → no attempt exists → go to **Assemble**.
+   - **`in_progress`** → read `ccaf-exam.sh get --field next_index`. Greet:
+     *"Welcome back — you're on question N of 60."* Ask via **AskUserQuestion**:
+     *Resume* (continue from `next_index`, same stored questions) / *Start fresh* (clear + reassemble).
+   - **`completed`** → tell them the previous attempt is finished. Ask via **AskUserQuestion**:
+     *Start a fresh attempt* / *Cancel*. A fresh attempt clears and reassembles.
+   - **Malformed / unreadable** (you read it and it isn't a valid exam file — missing frontmatter,
+     truncated blocks): explain briefly, do **not** score or administer it, and offer
+     *Start fresh* / *Cancel* via AskUserQuestion. Never crash; never score a damaged attempt.
+
+## Assemble
+
+Goal: a frozen, well-formed 60-question exam written to the attempt file.
+
+1. **Pick scenarios.** Choose **4 of the 6** scenarios at random (vary the choice across attempts;
+   don't always pick the same four). The six slugs are in the blueprint.
+2. **Domain quotas (hard constraint).** Exactly: **D1=16, D2=11, D3=12, D4=12, D5=9** (= 60).
+3. **Seed anchors.** Include the official seed questions whose `scenario` is among the four chosen
+   (verbatim — never reword or re-key them). They count toward their domain quotas.
+4. **Generate the remainder** up to 60, honoring the quotas and spread across the chosen scenarios.
+   Each generated question:
+   - tests a task statement for its tagged domain (see blueprint), stays strictly **in-scope**, and
+     never touches an **out-of-scope** topic;
+   - has one clearly-correct option and three plausible-but-wrong distractors;
+   - matches the official questions' style and difficulty (use them as few-shot anchors).
+5. **Verify each generated question independently.** For each, run an *independent* check that did
+   **not** see your authoring rationale — prefer spawning a fresh subagent via the Task tool that
+   receives only the question + options and must (a) pick the single defensible answer and (b) flag
+   any second-correct or implausible distractor. Reject and regenerate any question that fails
+   (budget ~3 tries); if it still fails, substitute another in-domain question or an unused seed.
+   Official seed questions are authoritative and skip this check.
+6. **Shuffle answer positions.** For every question (seed and generated), place the correct option
+   at a varied A–D position so the answer key carries no positional pattern across the exam.
+7. **Write the file** by piping the assembled body to `ccaf-exam.sh init` (one call, via stdin —
+   never the Write/Edit tools). Use exactly this schema:
+
+```
+---
+status: in_progress
+total: 60
+scenarios: <slug1>,<slug2>,<slug3>,<slug4>
+next_index: 1
+---
+[[Q1]]
+domain: D3
+scenario: code-generation
+source: official
+id: official-04
+stem: <question text — keep to one logical line; no blank lines inside the block>
+A) <option>
+B) <option>
+C) <option>
+D) <option>
+answer_key: A
+user_answer:
+[[Q2]]
+...
+```
+
+Rules for the body: one `[[Q<n>]]` block per question numbered 1..60 in order; each block has
+`domain:`, `scenario:`, `source:` (`official` or `generated`), `id:`, `stem:`, the four options,
+`answer_key:` (the correct letter after shuffling), and an empty `user_answer:`. Keep each block
+free of blank lines — the helper parses `user_answer:` as the block terminator.
+
+After writing, confirm with `ccaf-exam.sh get --field total` → should print `60`.
+
+## Administer
+
+Loop until the exam is fully answered:
+
+1. Read `ccaf-exam.sh get --field next_index`. If it is greater than `total` (60), go to **Score**.
+2. Read the file (`ccaf-exam.sh get`) and take the next **up to 4** unanswered questions starting
+   at `next_index`.
+3. Present them in **one AskUserQuestion call** (up to 4 questions per screen), each as a
+   single-select with the four options A–D. Show the stem and options **only** — never the
+   `answer_key`, never an explanation, never whether a prior answer was right.
+4. When the candidate submits the screen, record each answer:
+   `ccaf-exam.sh record --q <n> --answer <A|B|C|D>` (one call per question). This advances
+   `next_index` past the answered run, so quitting now and re-running resumes cleanly.
+5. Repeat. (A candidate may decline to answer a question; leave it unrecorded — it will score as
+   incorrect, and resume will return to it.)
+
+Do not capture or report time at any point.
+
+## Score
+
+1. Run `ccaf-exam.sh score`. It prints:
+   ```
+   correct=<n>/60
+   scaled=<100..1000>
+   verdict=<PASS|FAIL>
+   domain=D1 correct=.. total=..   (one line per D1..D5)
+   ```
+   and marks the file `completed`.
+2. Render a result screen like the real exam, e.g.:
+
+   ```
+   CCAF Mock Exam — Result (estimated)
+   Scaled score: 790 / 1000      PASS   (pass line: 720)
+
+   Per-domain:
+     D1 Agentic Architecture & Orchestration   13/16
+     D2 Tool Design & MCP Integration           8/11
+     D3 Claude Code Config & Workflows         10/12
+     D4 Prompt Engineering & Structured Output  9/12
+     D5 Context Management & Reliability         6/9   ← weakest
+   ```
+3. Add the disclaimer verbatim in spirit: *"This scaled score is an estimate
+   (scaled = 100 + 15 × correct, a linear mapping over the real 100–1000 band). It is NOT
+   Anthropic's proprietary equating curve. Treat 720+ here as a readiness signal, not a guarantee."*
+4. If PASS: note they're in good shape to book the real exam. If FAIL: point at the weakest
+   domain(s) from the breakdown as where to study. Do not persist, export, or share the result —
+   it's shown in the terminal only.
+
+## Integrity note
+
+The answer key lives in the attempt file (needed for resume and scoring). This is an honor-system
+gate — opening the file to peek only cheats the candidate before a paid attempt. Do not build
+obfuscation; just never *display* keys during administration.

--- a/ccaf/skills/ccaf-exam/SKILL.md
+++ b/ccaf/skills/ccaf-exam/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ccaf-exam
 description: "Engine for the /ccaf:mock-exam mock exam. Assembles a 60-question CCAF mock (official seed questions + verified generated ones), administers it 4 questions per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line. Use when running or resuming /ccaf:mock-exam."
+user-invocable: false
 ---
 
 # CCAF Mock Exam Engine

--- a/docs/specs/ccaf-mock-exam.md
+++ b/docs/specs/ccaf-mock-exam.md
@@ -1,0 +1,436 @@
+# Spec: A `/ccaf:mock-exam` mock-exam command that gates CCAF readiness at a scaled 720
+
+> Owned by: Dinesh (dinesh@incubyte.co) · Started: 2026-06-08 · Last revised: 2026-06-08 · Spec UUID: 7e3b9a10-ccaf-4f00-9b12-bee0e1a17001
+> Anthara spec — slice-decomposed, categorically-framed. Feeds /anthara:create-ticket and /anthara:develop.
+
+---
+
+## 1. Overview & business context
+
+The org has mandated the **Claude Certified Architect – Foundations (CCAF)** certification for everyone, with the policy: _take a practice exam first, and only attempt the real (paid) exam once you score 720+._ Today that means each person hand-rolls a quiz from the 40-page exam guide PDF — inconsistent, unrepeatable, and easy to get wrong. This spec defines `/ccaf:mock-exam`, a new command in a standalone **`ccaf`** Claude Code plugin that administers a faithful **60-question mock exam** end-to-end in the terminal and returns a scaled `/1000` score with the **720 pass line** plus a per-domain breakdown, so anyone can self-serve the readiness gate.
+
+The exam mirrors the real one on every replicable rule (60 questions, 4 of 6 scenarios, domain weighting 27/18/20/20/15, single-select MCQ, no penalty for guessing) and is honest about the one thing it cannot replicate: Anthropic's proprietary scaled-scoring curve. Questions are **assembled per run** from a small static seed bank (the 12 official sample questions from the guide, verbatim with their official explanations) plus model-generated questions that fill the remainder, each generated question passing an **independent verifier** before it is served. The attempt persists to a user-level file so it is **resumable**. It ships as the standalone `ccaf` plugin in the `incubyte-plugins` marketplace, so teammates install it and `/ccaf:mock-exam` appears; it runs fully offline.
+
+This is a LOW-risk, internal, honor-system developer tool: no regulated data, no central reporting, easy to revert.
+
+## 2. Sources
+
+| ID  | Type                                                              | Contributor    | Date       | Description                                                                                                                                                                                                                                                                                                                                                                       |
+| --- | ----------------------------------------------------------------- | -------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | CCAF Exam Guide (PDF)                                             | Anthropic, PBC | 2025-02-10 | `Claude+Certified+Architect+–+Foundations+Certification+Exam+Guide (1).pdf` — 5 domains + weightings, 6 scenarios, 12 sample questions with explanations, in/out-of-scope lists, prep exercises. Confidential NTK.                                                                                                                                                                |
+| 2   | Public corroboration (certsafari / tutorialsdojo / dev.to et al.) | Web            | 2026-06-08 | Corroborates exam length (60 questions) and duration (120 min); the PDF itself states scaled 100–1000, pass = 720.                                                                                                                                                                                                                                                                |
+| 3   | Codebase (`ai-plugins` repo; `ccaf` + sibling `bee`/`learn`)      | n/a            | 2026-06-08 | Claude Code plugin marketplace `incubyte-plugins`. `bee` = spec-driven TDD navigator: markdown `commands/`, `skills/*/SKILL.md`, `scripts/update-bee-state.sh` (silent state writer), `.claude/*.local.md` state (gitignored), `${CLAUDE_PLUGIN_ROOT}` paths. Sibling `learn` plugin ships `/learn:quiz` (one-at-a-time MCQ via AskUserQuestion, X/Y score, `.local.md` results). |
+| 4   | Research: LLM-generated MCQ failure modes                         | Web (arXiv)    | 2026-06-08 | Documented pitfalls: answer-position/selection bias, weak or secretly-correct distractors, wrong answer keys — motivating the independent-verifier requirement.                                                                                                                                                                                                                   |
+| 5   | Live brainstorm + spec session with Dinesh                        | Dinesh         | 2026-06-08 | All design decisions below (placement, hybrid sourcing, mock-only, resume, scoring formula, self-serve).                                                                                                                                                                                                                                                                          |
+
+Fabric MCP was unreachable this session; no compliance packs were resolvable. This is a non-regulated internal tool, so no pack-derived NFRs apply (see §6).
+
+## 3. Type ontology
+
+Categorical, non-overlapping, drawn from the exam guide [1] and the plugin conventions [3].
+
+### 3.1 Kinds of users
+
+- **Candidate** — a teammate taking the practice exam to decide whether they're ready for the real CCAF attempt [1, 5]. The only user role. No proctor, no admin, no reviewer.
+
+### 3.2 Kinds of data
+
+- **Blueprint** — the distilled, version-controlled encoding of the exam guide: the 5 domains with weights, the 6 scenarios, the in-scope/out-of-scope topic lists, and few-shot anchors. Read-only at runtime [1].
+- **Seed question** — an official question transcribed verbatim from the guide (the 12 sample questions), with its official correct answer and explanation. Authoritative; version-controlled [1].
+- **Generated question** — a model-authored question produced at assembly time to fill an exam to 60, grounded in the blueprint. Must pass the verifier before use [4, 5].
+- **Assembled exam** — a frozen set of exactly 60 questions for one attempt: the questions, their hidden answer keys, the candidate's recorded answers, and progress metadata. Lives in the local state file; never shared [5].
+- **Result** — the computed outcome of a completed exam: scaled score, pass/fail, and a per-domain breakdown. Displayed, never persisted as history [5].
+- **Verifier verdict** — for a generated question, a pass/fail judgment with reason, produced by an independent evaluation that did not author the question [4].
+
+None of this data is regulated (no PHI, PCI, PII).
+
+### 3.3 Kinds of events
+
+- **Exam started** — candidate runs `/ccaf:mock-exam` with no active attempt; assembly produces a new Assembled exam [5].
+- **Screen answered** — candidate submits a screen of (up to 4) answers; answers and the next-question pointer are persisted [5].
+- **Exam resumed** — candidate re-runs `/ccaf:mock-exam` while an in-progress attempt exists and chooses to continue [3, 5].
+- **Exam scored** — the final screen is answered; the Result is computed and shown [5].
+
+### 3.4 Kinds of states
+
+- **No attempt** — no active exam file exists for this candidate.
+- **In progress** — an Assembled exam exists with at least one unanswered question (`status: in_progress`).
+- **Completed** — every question answered and scored (`status: completed`).
+- **Unanswered (per question)** — a question with no recorded answer; scores as incorrect (no guessing penalty) [1].
+
+## 4. Invariants
+
+**4.1 Fixed length** — every Assembled exam contains exactly 60 questions. Sources: [1, 2, 5].
+
+**4.2 Domain weighting** — the 60 questions are distributed D1=16, D2=11, D3=12, D4=12, D5=9 (27/18/20/20/15 of 60, rounded to sum exactly 60). Sources: [1, 5].
+
+**4.3 Four scenarios** — exactly 4 of the 6 scenarios are represented in any Assembled exam, chosen at random per attempt. Sources: [1, 5].
+
+**4.4 Single correct answer** — every question has exactly one defensible correct option among A–D; the other three are plausible-but-wrong distractors. Sources: [1, 4].
+
+**4.5 Position carries no signal** — the correct option's letter is shuffled per question so answer position encodes nothing learnable across an exam. Sources: [4].
+
+**4.6 Official questions are authoritative and verbatim** — the 12 seed questions retain the guide's exact stem, options, correct answer, and explanation; they are never rewritten or re-keyed. Sources: [1].
+
+**4.7 No generated question is served unverified** — every Generated question passes the independent verifier (4.4 + 4.5 checks) before entering an Assembled exam; a failing question is regenerated or replaced, never shown. Sources: [4, 5].
+
+**4.8 Unanswered = incorrect** — there is no penalty for guessing and no negative marking; an unanswered question contributes zero correct. Sources: [1].
+
+**4.9 Scaled-score formula** — the scaled score uses the real exam's band: `scaled = 100 + round(correct ÷ 60 × 900)` (0 correct → 100, 60 correct → 1000); the candidate **passes iff `scaled ≥ 720`** (i.e. ≥ 42 of 60 correct). It is a transparent linear estimate over the 100–1000 band, not Anthropic's proprietary equating curve. Sources: [1, 5].
+
+**4.10 The local file is the single source of truth for an attempt** — resuming reconstructs the identical questions, order, and recorded answers from the file; nothing about an attempt lives only in conversation. Sources: [3, 5].
+
+**4.11 Answer keys stay hidden during administration** — keys and explanations are stored in the file (needed for resume + scoring) but are never displayed to the candidate until the Result screen. Honor-system caveat: a candidate can open the file; doing so only cheats themselves before a paid attempt. Sources: [5].
+
+**4.12 No timer, no sharing** — the exam is untimed (no time is stamped or reported), and no result is persisted as history, exported, or reported anywhere. Sources: [5].
+
+## 5. Slices
+
+Outside-in, independently verifiable, sequenced for build. The single user-reachable Entry is the `/ccaf:mock-exam` command; later slices attach behaviors to it.
+
+### 5.1 Ship the distilled blueprint and the 12-question seed bank
+
+Establish the read-only data foundation the command reads at runtime. Distill the exam guide [1] into `ccaf/data/ccaf-blueprint.md` — the 5 domains with their weights, the 6 scenarios (name + primary domains), the in-scope and out-of-scope topic lists, and the 12 official sample questions used as few-shot style/difficulty anchors. Transcribe those same 12 questions verbatim into `ccaf/data/ccaf-question-bank.md` as the static seed bank, each carrying its official correct answer, official explanation, and `domain` + `scenario` + `source: official` tags. From outside, this slice is "done" when both data files exist and a reader can confirm the 12 questions, their correct keys, and their tags match the guide exactly.
+
+- **Touches types:** Blueprint, Seed question.
+- **Preserves invariants:** 4.6.
+- **Affected modules:** `ccaf/data/ccaf-blueprint.md` (new), `ccaf/data/ccaf-question-bank.md` (new).
+- **Active packs:** none.
+- **Reachability:** `root → CCAF data files (blueprint + 12-question seed bank)`.
+
+Indicative seed-question schema (contract, not logic):
+
+```yaml
+- id: q-official-04
+  source: official # official | generated
+  domain: D3 # D1..D5
+  scenario: code-generation # one of the 6 scenario slugs
+  stem: "You want to create a custom /review slash command ... Where should you create this command file?"
+  options:
+    A: "In the .claude/commands/ directory in the project repository"
+    B: "In ~/.claude/commands/ in each developer's home directory"
+    C: "In the CLAUDE.md file at the project root"
+    D: "In a .claude/config.json file with a commands array"
+  correct: A
+  explanation: "Project-scoped slash commands live in .claude/commands/ ... (verbatim from guide)"
+```
+
+Domain/scenario tags for the 12 official questions (assembly anchors): Q1→D1·customer-support, Q2→D2·customer-support, Q3→D5·customer-support, Q4→D3·code-generation, Q5→D3·code-generation, Q6→D3·code-generation, Q7→D1·multi-agent-research, Q8→D5·multi-agent-research, Q9→D2·multi-agent-research, Q10→D3·claude-code-ci, Q11→D4·claude-code-ci, Q12→D4·claude-code-ci.
+
+**Acceptance criteria**
+
+- [x] **5.1.1** `ccaf/data/ccaf-blueprint.md` exists and records all 5 domains with weights 27/18/20/20/15 and the 6 scenario names with their primary domains.
+- [x] **5.1.2** The blueprint records the guide's in-scope and out-of-scope topic lists, so generation can be constrained to in-scope material.
+- [x] **5.1.3** `ccaf/data/ccaf-question-bank.md` contains all 12 official questions transcribed verbatim (stem, four options, correct key, explanation) with no edits to wording or answer keys.
+- [x] **5.1.4** Each of the 12 seed questions carries a `domain` tag (D1–D5), a `scenario` tag (one of the 6 slugs), and `source: official`, matching the mapping above.
+- [x] **5.1.5** The files contain no out-of-scope topics from the guide's exclusion list (e.g. fine-tuning, billing, vision, streaming).
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. Any structural check on the data files (well-formed schema, 12 questions present, weights sum correctly, every question has exactly one `correct` key) passes.
+
+(Steps 2–4 omitted: no schema/migrations, no UI surface.)
+
+### 5.2 Assemble a 60-question exam on `/ccaf:mock-exam`
+
+Create the `/ccaf:mock-exam` command and the `ccaf-exam` skill, and implement the **assemble** phase. The command (frontmatter: `description`, `argument-hint`, scoped `allowed-tools` including the pre-approved exam-state Bash helper, `AskUserQuestion`, `Skill`) loads `ccaf/skills/ccaf-exam/SKILL.md`. On a fresh run the skill: randomly selects 4 of the 6 scenarios (4.3); computes per-domain counts to satisfy 4.2; pulls the official seed questions whose scenario is in the selection as anchors; generates the remaining questions — grounded in the blueprint's in-scope material and few-shot anchors — to reach 60 while honoring the per-domain counts; runs each generated question through the **independent verifier** (a fresh evaluation, without the authoring rationale, that confirms exactly one defensible answer and three plausible-but-wrong distractors per 4.4, then shuffles A–D per 4.5); and writes the frozen Assembled exam to `~/.claude/ccaf-exam.local.md` with `status: in_progress`, empty answers, and `next_index` at the first question. From outside, "done" means running `/ccaf:mock-exam` (with no prior attempt) yields a well-formed local file of 60 questions with the correct domain distribution, the seed anchors embedded verbatim, hidden keys present, and answers empty.
+
+- **Touches types:** Blueprint, Seed question, Generated question, Assembled exam, Verifier verdict.
+- **Preserves invariants:** 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.10, 4.11.
+- **Affected modules:** `ccaf/commands/mock-exam.md` (new), `ccaf/skills/ccaf-exam/SKILL.md` (new), `ccaf/scripts/ccaf-exam.sh` (new, silent state writer), `ccaf/.claude-plugin/plugin.json` (new), `.claude-plugin/marketplace.json` (register `ccaf`), `ccaf/CLAUDE.md` (new), `.gitignore` (ignore the local exam file), `ccaf/data/*` (read).
+- **Active packs:** none.
+- **Reachability:** `CCAF data files (blueprint + 12-question seed bank) → /ccaf:mock-exam (assemble a new exam)`.
+
+Indicative local-file schema (contract, not logic):
+
+```markdown
+---
+status: in_progress # in_progress | completed
+total: 60
+scenarios:
+  [customer-support, code-generation, multi-agent-research, claude-code-ci]
+domain_counts: "D1:16,D2:11,D3:12,D4:12,D5:9"
+next_index: 1 # 1-based pointer to the next unanswered question
+---
+
+## Q1 [domain=D1 scenario=customer-support source=official id=q-official-01]
+
+<stem>
+A) ...
+B) ...
+C) ...
+D) ...
+answer_key: A                # hidden during administration
+user_answer:                 # blank until answered
+```
+
+```mermaid
+flowchart LR
+  CMD["/ccaf:mock-exam"] --> SK[ccaf-exam skill]
+  SK -->|reads| BP[ccaf-blueprint.md]
+  SK -->|reads| QB[ccaf-question-bank.md]
+  SK --> SEL[select 4 of 6 scenarios]
+  SEL --> CNT[compute domain counts 16/11/12/12/9]
+  CNT --> ANCH[pull matching official seeds]
+  ANCH --> GEN[generate remainder]
+  GEN --> VER{independent verifier}
+  VER -->|pass + shuffle A-D| ASM[assemble 60]
+  VER -->|fail| GEN
+  ASM -->|write once| FILE[~/.claude/ccaf-exam.local.md]
+```
+
+**Acceptance criteria**
+
+- [ ] **5.2.1** Running `/ccaf:mock-exam` with no existing attempt writes `~/.claude/ccaf-exam.local.md` containing exactly 60 questions (4.1).
+- [ ] **5.2.2** The assembled questions match the domain distribution D1=16, D2=11, D3=12, D4=12, D5=9 (4.2).
+- [ ] **5.2.3** Exactly 4 distinct scenarios are represented, selected at random across runs (4.3).
+- [x] **5.2.4** Official seed questions whose scenario is selected appear verbatim (stem, options, key, explanation unchanged) (4.6).
+- [ ] **5.2.5** Every generated question passes the verifier (exactly one defensible correct answer; three plausible-but-wrong distractors) before inclusion; a question that fails is regenerated or replaced, up to a bounded retry budget (default 3), after which a seed question or an alternative in-domain generation is substituted rather than serving an unverified item (4.4, 4.7).
+- [x] **5.2.6** Each question's correct-answer letter is shuffled so correct positions are not systematically biased across the exam (4.5).
+- [x] **5.2.7** The file is written with `status: in_progress`, `next_index: 1`, all `user_answer` blank, and every `answer_key` present but not surfaced in command output (4.10, 4.11).
+- [ ] **5.2.8** Generated questions stay within the blueprint's in-scope topics and never test an out-of-scope topic (5.1.5).
+- [x] **5.2.9** The `ccaf` plugin is registered (`plugin.json` + the `incubyte-plugins` marketplace entry) so `/ccaf:mock-exam` is available on install, and the local exam file path is gitignored.
+- [x] **5.2.10** Assembly works offline (no network/external API); generation and verification use only the agent and the shipped data files.
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. Assembly checks (count = 60, domain histogram = 16/11/12/12/9, exactly 4 scenarios, all keys present, no out-of-scope tags, shuffle produces non-degenerate position spread) pass.
+
+(Steps 2–4 omitted: no schema/migrations; the command is terminal-only, no browser UI surface.)
+
+### 5.3 Administer the exam four questions per screen, persisting after each screen
+
+Implement the **administer** phase. Reading the Assembled exam from the local file, the skill presents questions in screens of up to 4 via `AskUserQuestion` (each question a single-select A–D), starting at `next_index`. After each screen is answered, it records those `user_answer` values and advances `next_index` to the next unanswered question **by writing through the pre-approved Bash helper** (silent, no permission prompts), so progress is durable at every screen boundary. Answer keys and explanations are never shown during this phase. From outside, "done" means a candidate can answer all 60 questions in ~15 screens, and after each screen the local file reflects exactly the answers given and the correct `next_index`.
+
+- **Touches types:** Assembled exam, Candidate.
+- **Preserves invariants:** 4.8, 4.10, 4.11, 4.12.
+- **Affected modules:** `ccaf/skills/ccaf-exam/SKILL.md`, `ccaf/scripts/ccaf-exam.sh`.
+- **Active packs:** none.
+- **Reachability:** `/ccaf:mock-exam (assemble a new exam) → in-exam question screens`.
+
+**Acceptance criteria**
+
+- [x] **5.3.1** Questions are presented in screens of up to 4 via `AskUserQuestion`, each as a single-select A–D, beginning at `next_index`.
+- [x] **5.3.2** After every screen, the chosen answers are written to the corresponding `user_answer` fields and `next_index` advances past them, via the Bash helper with no permission prompt (mirrors the `update-bee-state.sh` pattern).
+- [x] **5.3.3** No `answer_key` or explanation is displayed at any point during administration (4.11).
+- [x] **5.3.4** Question stems, options, and order shown to the candidate are exactly those stored in the file (no re-generation or reordering mid-attempt) (4.10).
+- [x] **5.3.5** A candidate may leave a question unanswered (skip); it is recorded as unanswered and will score as incorrect (4.8).
+- [x] **5.3.6** No elapsed time is captured, displayed, or stored (4.12).
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. A simulated walkthrough confirms screens of ≤4, post-screen persistence of answers + `next_index`, and that keys are never emitted.
+
+(Steps 2–4 omitted: no schema/migrations; terminal-only.)
+
+### 5.4 Score the exam and show the readiness verdict
+
+Implement the **score** phase. When the final question is answered, the skill computes `correct` (unanswered = incorrect), the scaled score `100 + round(correct ÷ 60 × 900)` (a linear estimate over the real 100–1000 band), the pass/fail verdict (`pass iff scaled ≥ 720`), and a per-domain breakdown (correct/total per domain so the candidate sees where they're weak). It displays the result like the real exam screen — scaled `/1000` and pass/fail — accompanied by the honesty disclaimer, then sets the file `status: completed`. From outside, "done" means completing all 60 questions yields a correct scaled score, an accurate per-domain table, the right pass/fail call at the 720 line, and the disclaimer.
+
+- **Touches types:** Assembled exam, Result.
+- **Preserves invariants:** 4.8, 4.9, 4.12.
+- **Affected modules:** `ccaf/skills/ccaf-exam/SKILL.md`, `ccaf/scripts/ccaf-exam.sh`.
+- **Active packs:** none.
+- **Reachability:** `in-exam question screens → results & verdict screen`.
+
+Indicative result display (contract / shape, not logic):
+
+```
+CCAF Mock Exam — Result (estimated)
+Scaled score: 790 / 1000      PASS  (pass line: 720)
+
+Per-domain:
+  D1 Agentic Architecture & Orchestration   13/16
+  D2 Tool Design & MCP Integration           8/11
+  D3 Claude Code Config & Workflows          10/12
+  D4 Prompt Engineering & Structured Output   9/12
+  D5 Context Management & Reliability         6/9   ← weakest
+
+Disclaimer: This scaled score is an estimate (scaled = 100 + correct/60 x 900,
+a linear mapping over the real 100–1000 band). It is NOT Anthropic's proprietary
+equating curve. Treat 720+ here as a readiness signal, not a guarantee.
+```
+
+> @anthara: my bad, I made this mistake, lets follow the same marking as claude ccaf does.
+>
+> ✓ Resolved 2026-06-08: Reverted the custom `0%→0` mapping. The scaled score now uses the real exam's **100–1000 band** — `scaled = 100 + round(correct ÷ 60 × 900)`, pass at **720** (≥ 42/60), per the "linear over 100–1000" choice. CCAF's true raw→scaled curve is proprietary, so this is a transparent linear estimate over the real band, not the official curve. Cascaded to §4.9, the §5.4 intro, the result-display example (now 790/1000 for 46 correct), ACs 5.4.1 / 5.4.3 / 5.4.5, the slice Verification boundary cases, and §6.4. Sources: [1, 5].
+
+**Acceptance criteria**
+
+- [x] **5.4.1** On answering the final question, the scaled score is computed as `100 + round(correct ÷ 60 × 900)` over the 100–1000 band (4.9).
+- [x] **5.4.2** Unanswered questions count as incorrect in the raw `correct` total (4.8).
+- [x] **5.4.3** The verdict is PASS iff `scaled ≥ 720` (≥ 42/60), else FAIL — verified at the boundary (42 correct → 730 PASS; 41 correct → 715 FAIL).
+- [x] **5.4.4** A per-domain breakdown shows correct/total for each of D1–D5.
+- [x] **5.4.5** The output carries the disclaimer stating the score is a linear estimate over the real 100–1000 band, not Anthropic's proprietary equating curve.
+- [x] **5.4.6** After scoring, the file is set to `status: completed`; the verdict is shown only in the terminal and is not persisted as history, exported, or reported anywhere (4.12).
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. Boundary cases (42 correct = PASS/730; 41 = FAIL/715; 60 = 1000; 0 = 100; unanswered counted as wrong) and the per-domain tally pass.
+
+(Steps 2–4 omitted: no schema/migrations; terminal-only.)
+
+### 5.5 Resume an in-progress attempt
+
+Implement session resume. On startup the skill checks for an existing `~/.claude/ccaf-exam.local.md`. If one exists with `status: in_progress`, it greets the candidate ("Welcome back — you're on question N of 60") and offers, via `AskUserQuestion`, to **resume** (continue from `next_index` with the identical stored questions) or **start fresh** (discard and assemble a new exam). From outside, "done" means a candidate can quit mid-exam, re-run `/ccaf:mock-exam`, and continue exactly where they left off with the same questions and prior answers intact.
+
+- **Touches types:** Assembled exam.
+- **Preserves invariants:** 4.10.
+- **Affected modules:** `ccaf/skills/ccaf-exam/SKILL.md`, `ccaf/scripts/ccaf-exam.sh`, `ccaf/commands/mock-exam.md`.
+- **Active packs:** none.
+- **Reachability:** `in-exam question screens → "Welcome back" resume prompt`.
+
+**Acceptance criteria**
+
+- [ ] **5.5.1** On startup with an `in_progress` file present, the command surfaces a "Welcome back" prompt naming the current position (question N of 60) and offers Resume / Start fresh via `AskUserQuestion`.
+- [x] **5.5.2** Choosing Resume continues from `next_index` showing the identical stored questions, options, order, and previously recorded answers (4.10).
+- [ ] **5.5.3** Choosing Start fresh discards the existing attempt and assembles a new exam (per slice 5.2 behavior).
+- [x] **5.5.4** With no attempt file present, the command starts a new exam directly without a resume prompt.
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. A quit-and-resume sequence reconstructs the same exam and preserves prior answers; Start fresh discards cleanly.
+
+(Steps 2–4 omitted: no schema/migrations; terminal-only.)
+
+### 5.6 Handle fresh attempts after completion and resilient recovery
+
+Cover the remaining lifecycle and failure paths. After a `completed` attempt, re-running `/ccaf:mock-exam` offers to start a fresh attempt (a new random scenario set and freshly assembled questions, so retaking is meaningful rather than identical). If the local file is missing, malformed, or truncated, the command recovers gracefully — explaining the situation and offering to start fresh rather than crashing or scoring a corrupt attempt. From outside, "done" means completion → clean fresh-start path, and a damaged file → a friendly recovery, never a crash or a wrong score.
+
+- **Touches types:** Assembled exam, Result.
+- **Preserves invariants:** 4.1, 4.3, 4.10.
+- **Affected modules:** `ccaf/skills/ccaf-exam/SKILL.md`, `ccaf/scripts/ccaf-exam.sh`.
+- **Active packs:** none.
+- **Reachability:** `results & verdict screen → "start a fresh attempt" prompt` and `"Welcome back" resume prompt → corrupted/abandoned-file recovery`.
+
+**Acceptance criteria**
+
+- [ ] **5.6.1** Re-running `/ccaf:mock-exam` after a `completed` attempt offers to start a fresh attempt; accepting assembles a new exam with a freshly randomized scenario selection (4.3).
+- [ ] **5.6.2** A malformed/truncated/unreadable local file is detected; the command explains and offers to start fresh, and never scores or administers a corrupt attempt.
+- [ ] **5.6.3** A `completed` file is never silently re-scored or re-administered without the candidate choosing a fresh attempt.
+- [ ] **5.6.4** Starting fresh from any prior state (completed or corrupt) produces a valid 60-question exam satisfying 4.1–4.7.
+
+**Verification (slice complete when these pass):**
+
+1. **Tests.** Run the full test suite — all green. Re-run-after-completion, hand-corrupted file, and truncated file each resolve to a clean fresh-start path with no crash and no incorrect scoring.
+
+(Steps 2–4 omitted: no schema/migrations; terminal-only.)
+
+## 6. NFRs & regulatory compliance
+
+No compliance packs are active (Fabric MCP unreachable; the tool handles no regulated data). The following general non-functional requirements apply, drawn from the plugin's own conventions [3] and the integrity goals of the gate [4, 5]:
+
+**6.1 Permission-prompt-free state writes** — all writes to the active-attempt file go through a pre-approved Bash helper (`ccaf/scripts/ccaf-exam.sh`, scoped in `allowed-tools` exactly as `update-bee-state.sh` is), never Write/Edit, so administering 60 questions never spams permission prompts. Source: [3].
+
+**6.2 Privacy by location** — the attempt file lives at user-level `~/.claude/ccaf-exam.local.md`, and the path is added to `.gitignore`, so it is never committed or shared; no result is exported or reported. Sources: [3, 5] (invariant 4.12).
+
+**6.3 Offline operation** — taking the exam requires no network or external API; the blueprint and seed bank ship inside the plugin, and generation/verification/scoring run entirely on the agent. Source: [5] (AC 5.2.10).
+
+**6.4 Scoring honesty** — the scaled score is always labeled an estimate, never presented as Anthropic's official equating result; the disclaimer states the formula (a linear estimate over the real 100–1000 band) and that it is not Anthropic's proprietary equating curve. Sources: [1, 5] (invariant 4.9, AC 5.4.5).
+
+**6.5 Content fidelity & scope discipline** — official questions are verbatim (4.6); generated questions stay within the guide's in-scope topics and avoid the out-of-scope list (5.1.5, 5.2.8). Source: [1].
+
+**6.6 Question integrity** — no generated question is served without passing the independent verifier; answer positions are shuffled to remove bias (invariants 4.4, 4.5, 4.7). Source: [4].
+
+**6.7 AI-ergonomics & clean prose** — the command, skill, and data files follow `bee`'s prompt-artifact conventions (clear frontmatter, `${CLAUDE_PLUGIN_ROOT}` paths, focused SKILL.md) so they remain navigable and maintainable. Source: [3].
+
+There is no control-coverage matrix because no regulatory controls apply.
+
+## 7. Architecture
+
+### 7.1 Tech stack
+
+| Layer              | Choice                                                            | Rationale                                                                                                                        |
+| ------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime            | Claude Code plugin (`ccaf`) — Markdown command + `SKILL.md` + Bash | The deliverable is a slash command, not an app. It runs in the agent; "logic" is prompt orchestration plus a small shell helper. |
+| Orchestration      | `ccaf/commands/mock-exam.md` → `ccaf/skills/ccaf-exam/SKILL.md`          | Matches the established `bee`/`learn` pattern: a thin command loads a skill that holds the engine.                               |
+| Data (read-only)   | `ccaf/data/ccaf-blueprint.md`, `ccaf/data/ccaf-question-bank.md`    | Ships with the plugin so the exam runs offline; version-controlled, authoritative seed content.                                  |
+| State (read-write) | `~/.claude/ccaf-exam.local.md` via `ccaf/scripts/ccaf-exam.sh`     | User-level, gitignored, written silently by a pre-approved Bash helper — the proven `update-bee-state.sh` mechanism.             |
+| Interaction        | `AskUserQuestion` (≤4 single-selects per screen)                  | Clean A–D picking, no answer-code parsing, natural screen/persistence boundaries.                                                |
+
+### 7.2 Architectural style
+
+**Style:** _pipe-and-filter_ — a three-stage pipeline (**assemble → administer → score**) embedded in a prompt-orchestrated Claude Code plugin command, following `bee`'s modular, file-driven convention.
+
+**Why this style here:** the feature is naturally a linear pipeline over one artifact (the Assembled exam): assembly produces it, administration mutates it answer-by-answer, scoring reads it to a verdict. Each stage has a single responsibility and a clear input/output contract (the local file), which makes the stages independently testable and the attempt trivially resumable — the file _is_ the pipeline's persistent buffer between stages. It follows the established `bee`/`learn` plugin convention (command→skill→data/state layering) rather than inventing a new shape.
+
+**Dependency direction:** command depends on skill; skill depends on read-only data (blueprint, seed bank) and on the state helper; the state helper depends on nothing but the filesystem. Data files never depend on the skill; the verifier stage is independent of the generator stage (no shared rationale) by design.
+
+**Anti-patterns the style forbids:** no Write/Edit on the state file (helper only); no re-generating or reordering questions mid-attempt (the file is frozen once assembled); no serving a generated question that skipped verification; no surfacing answer keys before scoring; no network dependency.
+
+### 7.3 Module decomposition
+
+```mermaid
+graph LR
+  subgraph command
+    CMD["/ccaf:mock-exam (mock-exam.md)"]
+  end
+  subgraph skill
+    SK["ccaf-exam SKILL.md"]
+    ASM[assemble]
+    ADM[administer]
+    SCO[score]
+    SK --> ASM --> ADM --> SCO
+  end
+  subgraph data["data (read-only, shipped)"]
+    BP[ccaf-blueprint.md]
+    QB[ccaf-question-bank.md]
+  end
+  subgraph state["state (read-write, user-level)"]
+    HLP[ccaf-exam.sh]
+    FILE["~/.claude/ccaf-exam.local.md"]
+    HLP --> FILE
+  end
+  CMD --> SK
+  ASM --> BP
+  ASM --> QB
+  ADM --> HLP
+  ASM --> HLP
+  SCO --> HLP
+```
+
+| Module                           | Responsibility                                                            | Depends on               |
+| -------------------------------- | ------------------------------------------------------------------------- | ------------------------ |
+| `ccaf/commands/mock-exam.md`           | Command entry; frontmatter + allowed-tools; loads the skill; resume check | ccaf-exam skill          |
+| `ccaf/skills/ccaf-exam/SKILL.md`  | The engine: assemble → administer → score + resume/recovery               | data files, state helper |
+| `ccaf/data/ccaf-blueprint.md`     | Domains, weights, scenarios, scope lists, anchors                         | (nothing)                |
+| `ccaf/data/ccaf-question-bank.md` | 12 official seed questions                                                | (nothing)                |
+| `ccaf/scripts/ccaf-exam.sh`       | Silent init/record/get/score/clear on the local file                      | filesystem               |
+
+### 7.4 Data flow
+
+Covered by the assembly flowchart in slice 5.2 and the module graph above; runtime flow is otherwise linear (assemble → administer per screen → score) and needs no separate diagram.
+
+### 7.5 Threat model seed
+
+Not applicable beyond the honor-system caveat (4.11): the answer key is co-located with questions in the local file for resume/scoring, so a candidate can read it — accepted, since the only party harmed is the candidate before a paid attempt. No other trust boundary exists (single local user, no network, no shared data).
+
+## 8. Codebase impact map
+
+| Module                           | Slices that touch it    | Likely change shape                                        |
+| -------------------------------- | ----------------------- | ---------------------------------------------------------- |
+| `ccaf/commands/mock-exam.md`           | 5.2, 5.5                | New command file with frontmatter + allowed-tools          |
+| `ccaf/skills/ccaf-exam/SKILL.md`  | 5.2, 5.3, 5.4, 5.5, 5.6 | New skill: the assemble/administer/score engine            |
+| `ccaf/scripts/ccaf-exam.sh`       | 5.2, 5.3, 5.4, 5.5, 5.6 | New silent state helper (modeled on `update-bee-state.sh`) |
+| `ccaf/data/ccaf-blueprint.md`     | 5.1, 5.2                | New data file distilled from the guide                     |
+| `ccaf/data/ccaf-question-bank.md` | 5.1, 5.2                | New data file (12 official seed questions)                 |
+| `ccaf/.claude-plugin/plugin.json` | 5.2                    | New plugin manifest                                        |
+| `.claude-plugin/marketplace.json` | 5.2                    | Register the `ccaf` plugin                                 |
+| `ccaf/CLAUDE.md`                 | 5.2                     | New plugin guide                                           |
+| `.gitignore`                     | 5.2                     | Ignore the local exam file path                            |
+
+## 9. Open questions
+
+**9.1 Bank growth & v2 generation tuning.** v1 seeds with only the 12 official questions and generates the other ~48 per run. Over time the bank should grow with verified questions to reduce per-run generation load and improve quality. Awaiting: a follow-up effort (the build-time fan-out that authors + verifies additional seeds in parallel) — out of scope for v1.
+
+**9.2 Verifier prompt calibration.** The exact instructions that make the independent verifier reliably catch wrong keys / weak distractors will need empirical tuning against real generated output. Awaiting: build-time iteration and review of sample assembled exams.
+
+**9.3 Cross-attempt anti-memorization (future).** Because v1 generates fresh non-seed questions each run, memorization risk is already low; if a larger static bank is later introduced, a "don't repeat recently-seen questions" policy may be wanted. Awaiting: the v2 bank decision (9.1).
+
+---
+
+## Changelog
+
+- 2026-06-08 — Dinesh — Initial spec from the /anthara brainstorm → spec-writer chain [1, 5]. LOW risk; no compliance packs (Fabric unreachable).
+- 2026-06-08 — Dinesh (/anthara:collaboration-loop) — Resolved the §5.4 scoring annotation: switched the scaled-score mapping from the custom `0%→0` formula to a linear estimate over the real **100–1000** band (`scaled = 100 + round(correct ÷ 60 × 900)`, pass 720 = ≥ 42/60). Cascaded through §4.9, §5.4 (intro, result-display example → 790/1000, ACs 5.4.1/5.4.3/5.4.5, Verification boundaries), and §6.4.
+- 2026-06-09 — Dinesh (/anthara:develop) — Built the artifacts (data files, `ccaf-exam.sh` helper + 32-test harness, command, skill), enriched the blueprint with the full paraphrased syllabus, ran a live 8-question verification, then **relocated everything from `bee` into a standalone `ccaf` plugin** — command `/ccaf:mock-exam`, new `ccaf/.claude-plugin/plugin.json` + `ccaf/CLAUDE.md`, registered in the `incubyte-plugins` marketplace; reverted the `bee` CLAUDE.md and `.gitignore` edits. 24/35 ACs verified (test-suite- or live-run-backed); the remaining 11 need a full 60-question run + the resume/fresh/recovery prompt branches.


### PR DESCRIPTION
## What

Adds **`ccaf`**, a standalone Claude Code plugin that administers a faithful mock of the **Claude Certified Architect – Foundations (CCAF)** exam and reports a scaled readiness verdict — so anyone can self-check before booking the real (paid) exam, instead of hand-rolling a quiz from the guide PDF.

Run it with `/ccaf:mock-exam`.

## How it works

- **60-question weighted mock** — domains 27/18/20/20/15, 4 of 6 scenarios chosen at random, single-select MCQ, no penalty for guessing.
- **Question sourcing** — the 12 official sample questions (verbatim) seed the bank; the rest are generated from a paraphrased syllabus and pass an independent verifier (re-solve cold, plausible distractors, shuffled A–D positions).
- **Resumable** — the assembled attempt persists to `~/.claude/ccaf-exam.local.md`; quit and re-run to continue. Untimed, honor-system, fully offline.
- **Scoring** — `scaled = 100 + 15 × correct` (linear over the real 100–1000 band), pass = **720** (≥ 42/60), with a per-domain breakdown and an honest "estimate, not Anthropic's proprietary curve" disclaimer.

## Contents

- `ccaf/` plugin: `commands/mock-exam.md`, `skills/ccaf-exam/SKILL.md` (engine; `user-invocable: false` so only `/ccaf:mock-exam` shows in the menu), `data/ccaf-blueprint.md` (full paraphrased syllabus + scoring), `data/ccaf-question-bank.md` (12 official seeds), `scripts/ccaf-exam.sh` (silent state helper), `scripts/tests/ccaf-exam.test.sh`.
- Registered in `.claude-plugin/marketplace.json` as `ccaf`.
- Spec: `docs/specs/ccaf-mock-exam.md`.

## Verification

- **`ccaf/scripts/tests/ccaf-exam.test.sh`: 32/32 passing** — data-file structure, scaled-score math incl. the 42/41 pass boundary, `next_index` resume cursor, unanswered-as-incorrect, per-domain tally, lifecycle.
- A live 8-question run exercised assemble → administer (4-per-screen) → record/resume → score end-to-end.
- **24 / 35 spec ACs verified.** Deferred (tracked in the spec): the full 60-question assembly at scale (5.2.1–5.2.3, 5.2.8), the verifier-subagent path (5.2.5), and the resume/fresh/recovery prompt branches (5.5.1, 5.5.3, 5.6.1–5.6.4).

## Notes

- Internal repo: the syllabus in the blueprint is **paraphrased** (only the 12 official sample questions are verbatim), so this doesn't republish the NTK guide wholesale.
- The scaled score is a transparent estimate; the real exam's equating curve is proprietary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
