### PR TITLE
docs(ccaf): add README and LICENSE (MIT)

### DIFF
--- a/ccaf/.claude-plugin/plugin.json
+++ b/ccaf/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "Incubyte"
   },
-  "license": "Proprietary"
+  "license": "MIT"
 }

--- a/ccaf/LICENSE
+++ b/ccaf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2026] [Incubyte]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ccaf/README.md
+++ b/ccaf/README.md
@@ -1,0 +1,111 @@
+# CCAF
+
+CCAF is a Claude Code plugin that administers a faithful **mock** of the **Claude Certified Architect – Foundations** exam — right in your terminal — and gives you an honest readiness verdict before you book the real (paid) exam.
+
+**Why this exists.** Incubyte is having everyone get CCAF-certified, with a simple rule: *practice first, and only sit the real exam once you can reliably score 720+.* Instead of every engineer hand-rolling a quiz from the exam-guide PDF, this plugin makes that practice-and-gate a single command, consistent for the whole team.
+
+**What you get.** One command, `/ccaf:mock-exam`: a 60-question weighted mock that mirrors the real exam's structure, a scaled `/1000` score with the **720** pass line, and a per-domain breakdown that tells you exactly what to study. Resumable, untimed, fully offline.
+
+> Aim for 720+ here, then book the real exam.
+
+## How it mirrors the real exam
+
+| Real exam rule | This mock |
+| --- | --- |
+| 60 questions | ✅ 60 per attempt |
+| 5 domains, weighted 27 / 18 / 20 / 20 / 15 | ✅ same distribution (D1=16, D2=11, D3=12, D4=12, D5=9) |
+| 4 of 6 scenarios, chosen at random | ✅ same |
+| Single-select, 1 correct + 3 distractors | ✅ same |
+| No penalty for guessing | ✅ unanswered = incorrect |
+| Scaled 100–1000, pass = 720 | ✅ `scaled = 100 + 15 × correct`; pass at ≥ 42/60 |
+
+The one thing it **can't** replicate is Anthropic's proprietary scaled-scoring curve — so the score is a transparent, linear *estimate*, clearly labelled. Treat 720+ as a readiness signal, not a guarantee.
+
+## The flow
+
+```
+/ccaf:mock-exam
+       |
+       v
+  [ ASSEMBLE ]   Pick 4 of 6 scenarios; pull the official seed questions +
+       |          generate the rest (each independently verified, A–D shuffled);
+       |          freeze a 60-question exam to ~/.claude/ccaf-exam.local.md.
+       v
+  [ ADMINISTER ] 4 questions per screen. Progress saved after every screen —
+       |          quit any time and re-run to resume where you left off.
+       v
+  [ SCORE ]      Scaled /1000, PASS/FAIL at 720, per-domain breakdown, and an
+                  honest "this is an estimate" disclaimer.
+```
+
+## Install
+
+In Claude Code:
+
+```bash
+# Add the Incubyte marketplace
+/plugin marketplace add incubyte/ai-plugins
+
+# Install CCAF
+/plugin install ccaf@incubyte-plugins
+```
+
+> Restart (or `/reload-plugins`) after installing.
+
+## Usage
+
+```bash
+/ccaf:mock-exam
+```
+
+Answer the questions four to a screen. When you finish, you get your scaled score, a PASS/FAIL at 720, and a domain-by-domain breakdown so you know where you're weak.
+
+```bash
+/ccaf:mock-exam fresh
+```
+
+Discard any in-progress or completed attempt and assemble a brand-new exam.
+
+**Resume:** the attempt persists to `~/.claude/ccaf-exam.local.md`. Close your terminal mid-exam and re-run `/ccaf:mock-exam` — it greets you with "Welcome back" and continues from the next unanswered question.
+
+**Honor system:** untimed, self-serve, nothing reported or shared. The answer key lives in the attempt file so resume and scoring work — peeking only cheats you before a paid exam.
+
+## How scoring works
+
+- Raw `correct` = questions answered correctly (unanswered count as incorrect).
+- `scaled = 100 + 15 × correct` — a linear mapping over the real 100–1000 band (equivalently `100 + round(correct ÷ 60 × 900)`; since `900 ÷ 60 = 15`, no rounding is needed).
+- **Pass** iff `scaled ≥ 720`, i.e. **≥ 42 of 60** correct.
+- A per-domain breakdown (correct / total per D1–D5) accompanies every result.
+
+## What's inside
+
+```
+ccaf/
+├── .claude-plugin/
+│   └── plugin.json                # Plugin manifest
+├── commands/
+│   └── mock-exam.md               # /ccaf:mock-exam — the entry point
+├── skills/
+│   └── ccaf-exam/
+│       └── SKILL.md               # engine: assemble → administer → score (internal)
+├── data/
+│   ├── ccaf-blueprint.md          # domains, weights, scenarios, paraphrased syllabus, scoring
+│   └── ccaf-question-bank.md      # the 12 official sample questions (verbatim seeds + anchors)
+├── scripts/
+│   ├── ccaf-exam.sh               # silent state helper (init / get / record / score / clear)
+│   └── tests/
+│       └── ccaf-exam.test.sh      # shell test harness for the data files + helper logic
+├── CLAUDE.md                      # plugin conventions
+├── README.md
+└── LICENSE
+```
+
+## Notes
+
+- **Question sourcing.** The 12 official sample questions seed the bank (verbatim) and anchor style/difficulty; the rest are generated from a paraphrased syllabus and pass an independent verifier (re-solve cold, plausible distractors, shuffled positions) before being served.
+- **Confidentiality.** The syllabus in `ccaf-blueprint.md` is *paraphrased* — only the 12 official sample questions are verbatim — so this internal repo doesn't republish the exam guide wholesale.
+- **Roadmap.** v1 leans on a small seed bank + generation; growing a larger verified bank, adding a short per-domain "practice" mode, and verifying the full lifecycle end-to-end are the next steps (tracked in `docs/specs/ccaf-mock-exam.md`).
+
+## License
+
+MIT


### PR DESCRIPTION
Follow-up to #43 (now merged). Adds the standard plugin docs/license files to `ccaf`.

- **`ccaf/README.md`** — bee-style: what/why, a real-exam fidelity table, the assemble → administer → score flow, install + usage, scoring, project layout, and notes (paraphrased syllabus, estimate disclaimer, roadmap).
- **`ccaf/LICENSE`** — MIT (the license `bee` actually ships).
- **`ccaf/.claude-plugin/plugin.json`** — license aligned `Proprietary` → `MIT` for internal consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
