### PR TITLE
refactor(ccaf): replace seed bank with original self-authored questions

### DIFF
--- a/ccaf/.claude-plugin/plugin.json
+++ b/ccaf/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccaf",
   "version": "0.1.0",
-  "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. Assembles a 60-question weighted mock (official seed questions + verified generated ones), administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown. Run /ccaf:mock-exam.",
+  "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. Assembles a 60-question weighted mock (curated seed questions + verified generated ones), administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown. Run /ccaf:mock-exam.",
   "author": {
     "name": "Incubyte"
   },

--- a/ccaf/CLAUDE.md
+++ b/ccaf/CLAUDE.md
@@ -8,8 +8,8 @@ readiness before booking the real (paid) exam.
 
 - `commands/mock-exam.md` — the `/ccaf:mock-exam` command (loads the engine skill).
 - `skills/ccaf-exam/SKILL.md` — the assemble → administer → score engine.
-- `data/ccaf-blueprint.md` — domains, weights, scenarios, the paraphrased syllabus, scope lists, scoring.
-- `data/ccaf-question-bank.md` — the 12 official sample questions (verbatim), used as seeds + anchors.
+- `data/ccaf-blueprint.md` — domains, weights, scenarios, the syllabus, scope lists, scoring.
+- `data/ccaf-question-bank.md` — 12 self-authored seed questions, used as seeds + anchors.
 - `scripts/ccaf-exam.sh` — silent state helper (init / get / record / score / clear); never use Write/Edit on the attempt file.
 - `scripts/tests/ccaf-exam.test.sh` — shell test harness for the data files + helper logic.
 

--- a/ccaf/README.md
+++ b/ccaf/README.md
@@ -27,7 +27,7 @@ The one thing it **can't** replicate is Anthropic's proprietary scaled-scoring c
 /ccaf:mock-exam
        |
        v
-  [ ASSEMBLE ]   Pick 4 of 6 scenarios; pull the official seed questions +
+  [ ASSEMBLE ]   Pick 4 of 6 scenarios; pull the seed questions +
        |          generate the rest (each independently verified, A–D shuffled);
        |          freeze a 60-question exam to ~/.claude/ccaf-exam.local.md.
        v
@@ -90,7 +90,7 @@ ccaf/
 │       └── SKILL.md               # engine: assemble → administer → score (internal)
 ├── data/
 │   ├── ccaf-blueprint.md          # domains, weights, scenarios, paraphrased syllabus, scoring
-│   └── ccaf-question-bank.md      # the 12 official sample questions (verbatim seeds + anchors)
+│   └── ccaf-question-bank.md      # 12 self-authored seed questions (seeds + anchors)
 ├── scripts/
 │   ├── ccaf-exam.sh               # silent state helper (init / get / record / score / clear)
 │   └── tests/
@@ -102,8 +102,7 @@ ccaf/
 
 ## Notes
 
-- **Question sourcing.** The 12 official sample questions seed the bank (verbatim) and anchor style/difficulty; the rest are generated from a paraphrased syllabus and pass an independent verifier (re-solve cold, plausible distractors, shuffled positions) before being served.
-- **Confidentiality.** The syllabus in `ccaf-blueprint.md` is *paraphrased* — only the 12 official sample questions are verbatim — so this internal repo doesn't republish the exam guide wholesale.
+- **Question sourcing.** The 12 self-authored seed questions seed the bank and anchor style/difficulty; the rest are generated from the blueprint syllabus and pass an independent verifier (re-solve cold, plausible distractors, shuffled positions) before being served.
 - **Roadmap.** v1 leans on a small seed bank + generation; growing a larger verified bank, adding a short per-domain "practice" mode, and verifying the full lifecycle end-to-end are the next steps (tracked in `docs/specs/ccaf-mock-exam.md`).
 
 ## License

--- a/ccaf/data/ccaf-blueprint.md
+++ b/ccaf/data/ccaf-blueprint.md
@@ -5,9 +5,8 @@ exam guide (Anthropic, PBC; guide v0.1, 2025-02-10). This is the read-only autho
 `/ccaf:mock-exam` command's `ccaf-exam` skill uses to assemble a mock exam. It is **not** shared or
 modified at runtime.
 
-The syllabus below is **paraphrased** from the official guide (an internal NTK document) so this
-repo does not republish it verbatim. The only verbatim content is the 12 official sample questions
-in `ccaf-question-bank.md`, which are the explicit learner-practice anchors. Generated questions
+The syllabus below is distilled from the public CCAF exam-guide structure — its domains, scenarios,
+and scope. The seed questions in `ccaf-question-bank.md` are self-authored. Generated questions
 must test the points below and stay strictly inside the in-scope list.
 
 > The official scaled-scoring curve is proprietary and unpublished. This mock approximates it
@@ -311,7 +310,7 @@ comparison; prompt-caching internals (beyond "it exists"); tokenization specific
 
 ## Few-shot anchors
 
-The 12 official sample questions in `ccaf-question-bank.md` are the authoritative style,
+The 12 self-authored seed questions in `ccaf-question-bank.md` are the style,
 difficulty, and explanation-tone anchors. Generated questions should match their shape:
 a realistic production scenario, one clearly-correct option, and three distractors that a
 candidate with incomplete knowledge might plausibly pick (build distractors from the anti-patterns

--- a/ccaf/data/ccaf-question-bank.md
+++ b/ccaf/data/ccaf-question-bank.md
@@ -1,309 +1,258 @@
 # CCAF Mock Exam — Seed Question Bank
 
-The 12 official sample questions from the CCAF exam guide, transcribed verbatim with their
-official correct answers and explanations. These are **authoritative** (invariant 4.6): never
-rewrite, re-key, or paraphrase. They seed assembled exams as anchors and are also the few-shot
-style reference for generated questions.
+A curated set of **12 self-authored seed questions** spanning the five domains and the scenario
+contexts. They seed assembled exams (as anchors) and set the style/difficulty reference for
+generated questions. Stable and version-controlled — not regenerated at runtime. The assembler
+may shuffle option order at serve time (invariant 4.5); the `correct` letter below refers to the
+option text, not a fixed position.
 
-Each entry: stable `id`, `source: official`, `domain` (D1–D5), `scenario` slug, `stem`, four
-`options`, the `correct` letter, and the official `explanation`. The assembler may shuffle option
-order at serve time (invariant 4.5); the `correct` letter here refers to the option text, not a
-fixed position.
+Each entry: stable `id`, `source: authored`, `domain` (D1–D5), `scenario` slug, `stem`, four
+`options`, the `correct` letter, and an `explanation` that says why the right answer is right and
+why the distractors are wrong.
 
 ```yaml
 questions:
-  - id: official-01
-    source: official
+  - id: seed-01
+    source: authored
     domain: D1
     scenario: customer-support
     stem: >-
-      Production data shows that in 12% of cases, your agent skips get_customer entirely and
-      calls lookup_order using only the customer's stated name, occasionally leading to
-      misidentified accounts and incorrect refunds. What change would most effectively address
-      this reliability issue?
+      Your support agent must confirm a customer's identity with verify_identity before it calls
+      issue_credit. In testing it usually does, but in roughly 1 in 10 sessions it issues a credit
+      first. The fix has to be reliable because credits move money. What is the best approach?
     options:
-      A: Add a programmatic prerequisite that blocks lookup_order and process_refund calls until get_customer has returned a verified customer ID.
-      B: Enhance the system prompt to state that customer verification via get_customer is mandatory before any order operations.
-      C: Add few-shot examples showing the agent always calling get_customer first, even when customers volunteer order details.
-      D: Implement a routing classifier that analyzes each request and enables only the subset of tools appropriate for that request type.
+      A: Add a prerequisite gate (hook) that blocks issue_credit until verify_identity has succeeded.
+      B: Strengthen the system prompt to require identity verification before any credit.
+      C: Add few-shot examples that always verify identity before issuing a credit.
+      D: Lower the model temperature so it follows the ordering instruction more reliably.
     correct: A
     explanation: >-
-      When a specific tool sequence is required for critical business logic (like verifying
-      customer identity before processing refunds), programmatic enforcement provides
-      deterministic guarantees that prompt-based approaches cannot. Options B and C rely on
-      probabilistic LLM compliance, which is insufficient when errors have financial
-      consequences. Option D addresses tool availability rather than tool ordering, which is not
-      the actual problem.
+      Money-moving steps need deterministic enforcement. A programmatic prerequisite (hook/gate)
+      guarantees the order; prompt strengthening (B) and few-shot (C) only reduce — never eliminate —
+      the failure rate, which is unacceptable when errors move money. Temperature (D) does not
+      guarantee tool ordering.
 
-  - id: official-02
-    source: official
+  - id: seed-02
+    source: authored
     domain: D2
     scenario: customer-support
     stem: >-
-      Production logs show the agent frequently calls get_customer when users ask about orders
-      (e.g., "check my order #12345"), instead of calling lookup_order. Both tools have minimal
-      descriptions ("Retrieves customer information" / "Retrieves order details") and accept
-      similar identifier formats. What's the most effective first step to improve tool selection
-      reliability?
+      Your agent keeps calling check_balance when users ask to "see my recent transactions," which
+      should route to list_transactions. Both tools are described only as "Returns account data."
+      What is the most effective first step to fix tool selection?
     options:
-      A: Add few-shot examples to the system prompt demonstrating correct tool selection patterns, with 5-8 examples showing order-related queries routing to lookup_order.
-      B: Expand each tool's description to include input formats it handles, example queries, edge cases, and boundaries explaining when to use it versus similar tools.
-      C: Implement a routing layer that parses user input before each turn and pre-selects the appropriate tool based on detected keywords and identifier patterns.
-      D: Consolidate both tools into a single lookup_entity tool that accepts any identifier and internally determines which backend to query.
-    correct: B
+      A: Add a pre-turn keyword router that maps phrases to tools before the model runs.
+      B: Merge the two tools into a single get_account tool.
+      C: Rewrite each tool's description with its purpose, inputs, example queries, and when to use it versus the other.
+      D: Add ten few-shot routing examples to the system prompt.
+    correct: C
     explanation: >-
-      Tool descriptions are the primary mechanism LLMs use for tool selection. When descriptions
-      are minimal, models lack the context to differentiate between similar tools. Option B
-      directly addresses this root cause with a low-effort, high-leverage fix. Few-shot examples
-      (A) add token overhead without fixing the underlying issue. A routing layer (C) is
-      over-engineered and bypasses the LLM's natural language understanding. Consolidating tools
-      (D) is a valid architectural choice but requires more effort than a "first step" warrants
-      when the immediate problem is inadequate descriptions.
+      Tool descriptions are the model's primary selection signal; enriching them is the low-effort,
+      root-cause fix. A router (A) over-engineers and bypasses the model's understanding; merging (B)
+      is a larger change than a "first step"; few-shot (D) adds tokens without addressing the thin
+      descriptions.
 
-  - id: official-03
-    source: official
+  - id: seed-03
+    source: authored
     domain: D5
     scenario: customer-support
     stem: >-
-      Your agent achieves 55% first-contact resolution, well below the 80% target. Logs show it
-      escalates straightforward cases (standard damage replacements with photo evidence) while
-      attempting to autonomously handle complex situations requiring policy exceptions. What's
-      the most effective way to improve escalation calibration?
+      A billing agent escalates simple in-policy refunds to humans, yet tries to resolve unusual
+      cases the policy does not cover. First-contact resolution is low. What is the most
+      proportionate first improvement?
     options:
-      A: Add explicit escalation criteria to your system prompt with few-shot examples demonstrating when to escalate versus resolve autonomously.
-      B: Have the agent self-report a confidence score (1-10) before each response and automatically route requests to humans when confidence falls below a threshold.
-      C: Deploy a separate classifier model trained on historical tickets to predict which requests need escalation before the main agent begins processing.
-      D: Implement sentiment analysis to detect customer frustration levels and automatically escalate when negative sentiment exceeds a threshold.
-    correct: A
+      A: Route to a human whenever the model's self-reported confidence is below 8/10.
+      B: Train a separate classifier on historical tickets to predict which cases to escalate.
+      C: Auto-escalate whenever the customer's sentiment turns negative.
+      D: Add explicit escalate-versus-resolve criteria, with few-shot examples, to the system prompt.
+    correct: D
     explanation: >-
-      Adding explicit escalation criteria with few-shot examples directly addresses the root
-      cause: unclear decision boundaries. This is the proportionate first response before adding
-      infrastructure. Option B fails because LLM self-reported confidence is poorly calibrated —
-      the agent is already incorrectly confident on hard cases. Option C is over-engineered,
-      requiring labeled data and ML infrastructure when prompt optimization hasn't been tried.
-      Option D solves a different problem entirely; sentiment doesn't correlate with case
-      complexity, which is the actual issue.
+      The root cause is unclear decision boundaries, which explicit criteria plus examples fix
+      proportionately. LLM self-confidence (A) is poorly calibrated; a trained classifier (B) is
+      over-built before prompt optimization is tried; sentiment (C) does not track case complexity.
 
-  - id: official-04
-    source: official
+  - id: seed-04
+    source: authored
     domain: D3
     scenario: code-generation
     stem: >-
-      You want to create a custom /review slash command that runs your team's standard code
-      review checklist. This command should be available to every developer when they clone or
-      pull the repository. Where should you create this command file?
+      You wrote a /standup slash command and want every teammate to get it automatically when they
+      clone or pull the repository. Where should the command file live?
     options:
-      A: In the .claude/commands/ directory in the project repository
-      B: In ~/.claude/commands/ in each developer's home directory
-      C: In the CLAUDE.md file at the project root
-      D: In a .claude/config.json file with a commands array
-    correct: A
+      A: In ~/.claude/commands/standup.md in each developer's home directory.
+      B: In .claude/commands/standup.md committed to the repository.
+      C: In a "commands" section of the root CLAUDE.md.
+      D: In a .claude/config.json file with a commands array.
+    correct: B
     explanation: >-
-      Project-scoped custom slash commands should be stored in the .claude/commands/ directory
-      within the repository. These commands are version-controlled and automatically available to
-      all developers when they clone or pull the repo. Option B (~/.claude/commands/) is for
-      personal commands that aren't shared via version control. Option C (CLAUDE.md) is for
-      project instructions and context, not command definitions. Option D describes a
-      configuration mechanism that doesn't exist in Claude Code.
+      Project-scoped commands live in .claude/commands/ and ship via version control, so everyone
+      gets them on clone/pull. ~/.claude (A) is personal and not shared; CLAUDE.md (C) holds context,
+      not command definitions; (D) is not a real Claude Code mechanism.
 
-  - id: official-05
-    source: official
+  - id: seed-05
+    source: authored
     domain: D3
     scenario: code-generation
     stem: >-
-      You've been assigned to restructure the team's monolithic application into microservices.
-      This will involve changes across dozens of files and requires decisions about service
-      boundaries and module dependencies. Which approach should you take?
+      You must split a shared "utils" module into well-bounded packages across about 30 files, and
+      there are a couple of reasonable ways to draw the boundaries. How should you start in Claude
+      Code?
     options:
-      A: Enter plan mode to explore the codebase, understand dependencies, and design an implementation approach before making changes.
-      B: Start with direct execution and make changes incrementally, letting the implementation reveal the natural service boundaries.
-      C: Use direct execution with comprehensive upfront instructions detailing exactly how each service should be structured.
-      D: Begin in direct execution mode and only switch to plan mode if you encounter unexpected complexity during implementation.
-    correct: A
+      A: Direct execution driven by one detailed, up-front instruction set.
+      B: Direct execution, refactoring file by file and letting the boundaries emerge.
+      C: Direct execution, switching to plan mode only if it becomes messy.
+      D: Plan mode, to map dependencies and decide the boundary design before editing.
+    correct: D
     explanation: >-
-      Plan mode is designed for complex tasks involving large-scale changes, multiple valid
-      approaches, and architectural decisions — exactly what monolith-to-microservices
-      restructuring requires. It enables safe codebase exploration and design before committing
-      to changes. Option B risks costly rework when dependencies are discovered late. Option C
-      assumes you already know the right structure without exploring the code. Option D ignores
-      that the complexity is already stated in the requirements, not something that might emerge
-      later.
+      Multi-file scope, multiple valid approaches, and a structural decision point call for plan mode
+      — explore and design before committing. The complexity is known up front, so deferring planning
+      (B, C) risks costly rework, and (A) assumes the design is already settled.
 
-  - id: official-06
-    source: official
+  - id: seed-06
+    source: authored
     domain: D3
     scenario: code-generation
     stem: >-
-      Your codebase has distinct areas with different coding conventions: React components use
-      functional style with hooks, API handlers use async/await with specific error handling, and
-      database models follow a repository pattern. Test files are spread throughout the codebase
-      alongside the code they test (e.g., Button.test.tsx next to Button.tsx), and you want all
-      tests to follow the same conventions regardless of location. What's the most maintainable
-      way to ensure Claude automatically applies the correct conventions when generating code?
+      Your repo mixes services with different styles, and you want one set of conventions applied to
+      every file matching **/*.handler.ts regardless of which directory it sits in. What is the most
+      maintainable setup?
     options:
-      A: Create rule files in .claude/rules/ with YAML frontmatter specifying glob patterns to conditionally apply conventions based on file paths
-      B: Consolidate all conventions in the root CLAUDE.md file under headers for each area, relying on Claude to infer which section applies
-      C: Create skills in .claude/skills/ for each code type that include the relevant conventions in their SKILL.md files
-      D: Place a separate CLAUDE.md file in each subdirectory containing that area's specific conventions
+      A: A .claude/rules/ file with `paths: ["**/*.handler.ts"]` glob frontmatter.
+      B: One large root CLAUDE.md with a section per convention.
+      C: A skill per service that the developer loads manually.
+      D: A CLAUDE.md placed in each directory that contains handler files.
     correct: A
     explanation: >-
-      Option A is correct because .claude/rules/ with glob patterns (e.g., **/*.test.tsx) allows
-      conventions to be automatically applied based on file paths regardless of directory
-      location — essential for test files spread throughout the codebase. Option B relies on
-      inference rather than explicit matching, making it unreliable. Option C requires manual
-      skill invocation or relies on Claude choosing to load them, contradicting the need for
-      deterministic "automatic" application based on file paths. Option D can't easily handle
-      files spread across many directories since CLAUDE.md files are directory-bound.
+      Path-scoped rules with glob frontmatter apply by file pattern across directories — exactly the
+      scattered-files case. Root CLAUDE.md (B) relies on inference; manual skills (C) are not
+      automatic; per-directory CLAUDE.md files (D) cannot cleanly span files spread across the tree.
 
-  - id: official-07
-    source: official
+  - id: seed-07
+    source: authored
     domain: D1
     scenario: multi-agent-research
     stem: >-
-      After running the system on the topic "impact of AI on creative industries," you observe
-      that each subagent completes successfully, but the final reports cover only visual arts,
-      completely missing music, writing, and film production. The coordinator's logs show it
-      decomposed the topic into "AI in digital art creation," "AI in graphic design," and "AI in
-      photography." What is the most likely root cause?
+      Asked to cover "the global impact of remote work," your research system returns a thorough
+      report — but only about the software industry, ignoring healthcare, education, and
+      manufacturing. Each subagent handled its assigned subtopic well. What is the most likely root
+      cause?
     options:
-      A: The synthesis agent lacks instructions for identifying coverage gaps in the findings it receives from other agents.
-      B: The coordinator agent's task decomposition is too narrow, resulting in subagent assignments that don't cover all relevant domains of the topic.
-      C: The web search agent's queries are not comprehensive enough and need to be expanded to cover more creative industry sectors.
-      D: The document analysis agent is filtering out sources related to non-visual creative industries due to overly restrictive relevance criteria.
-    correct: B
+      A: The synthesis agent failed to flag coverage gaps in what it received.
+      B: The web-search agent's queries were not broad enough.
+      C: The coordinator decomposed the topic too narrowly, so whole sectors were never assigned.
+      D: The document-analysis agent filtered out non-software sources.
+    correct: C
     explanation: >-
-      The coordinator's logs reveal the root cause directly: it decomposed "creative industries"
-      into only visual arts subtasks (digital art, graphic design, photography), completely
-      omitting music, writing, and film. The subagents executed their assigned tasks correctly —
-      the problem is what they were assigned. Options A, C, and D incorrectly blame downstream
-      agents that are working correctly within their assigned scope.
+      The subagents executed their assignments correctly; the gap is in what the coordinator chose to
+      assign. Options A, B, and D blame downstream agents that worked correctly within the scope they
+      were given.
 
-  - id: official-08
-    source: official
+  - id: seed-08
+    source: authored
     domain: D5
     scenario: multi-agent-research
     stem: >-
-      The web search subagent times out while researching a complex topic. You need to design how
-      this failure information flows back to the coordinator agent. Which error propagation
-      approach best enables intelligent recovery?
+      A document-fetch subagent receives a 503 from a source. How should it report the failure so the
+      coordinator can recover intelligently?
     options:
-      A: Return structured error context to the coordinator including the failure type, the attempted query, any partial results, and potential alternative approaches.
-      B: Implement automatic retry logic with exponential backoff within the subagent, returning a generic "search unavailable" status only after all retries are exhausted.
-      C: Catch the timeout within the subagent and return an empty result set marked as successful.
-      D: Propagate the timeout exception directly to a top-level handler that terminates the entire research workflow.
-    correct: A
+      A: Retry silently with backoff and, if all retries fail, return "fetch failed."
+      B: Return structured context — failure type, what was attempted, any partial results, and possible alternatives.
+      C: Return an empty result marked successful so the pipeline keeps moving.
+      D: Throw the error to a top-level handler that aborts the entire research run.
+    correct: B
     explanation: >-
-      Structured error context gives the coordinator the information it needs to make intelligent
-      recovery decisions — whether to retry with a modified query, try an alternative approach, or
-      proceed with partial results. Option B's generic status hides valuable context from the
-      coordinator, preventing informed decisions. Option C suppresses the error by marking failure
-      as success, which prevents any recovery and risks incomplete research outputs. Option D
-      terminates the entire workflow unnecessarily when recovery strategies could succeed.
+      Structured error context lets the coordinator decide whether to retry, reroute, or proceed with
+      partial results. A generic status (A) hides that context; marking failure as success (C)
+      silently drops coverage; aborting the whole run (D) is disproportionate to one source failing.
 
-  - id: official-09
-    source: official
+  - id: seed-09
+    source: authored
     domain: D2
     scenario: multi-agent-research
     stem: >-
-      The synthesis agent frequently needs to verify specific claims while combining findings.
-      Currently it returns control to the coordinator, which invokes the web search agent, then
-      re-invokes synthesis — adding 2-3 round trips and 40% latency. 85% of these verifications
-      are simple fact-checks (dates, names, statistics) while 15% require deeper investigation.
-      What's the most effective approach to reduce overhead while maintaining reliability?
+      Your synthesis agent frequently confirms small facts (dates, figures) mid-write by round-tripping
+      through the coordinator to the search agent, adding latency. About 80% are trivial lookups and
+      20% need real investigation. What is the most effective fix?
     options:
-      A: Give the synthesis agent a scoped verify_fact tool for simple lookups, while complex verifications continue delegating to the web search agent through the coordinator.
-      B: Have the synthesis agent accumulate all verification needs and return them as a batch to the coordinator at the end of its pass, which then sends them all to the web search agent at once.
-      C: Give the synthesis agent access to all web search tools so it can handle any verification need directly without round-trips through the coordinator.
-      D: Have the web search agent proactively cache extra context around each source during initial research, anticipating what the synthesis agent might need to verify.
-    correct: A
+      A: Give the synthesis agent access to every search tool so it never round-trips.
+      B: Have it batch all verification needs and send them to the coordinator at the end of the pass.
+      C: Have the search agent pre-cache extra context around each source in case synthesis needs it.
+      D: Give synthesis a narrow verify_fact tool for simple lookups, keeping coordinator-routed search for the complex 20%.
+    correct: D
     explanation: >-
-      Option A applies the principle of least privilege by giving the synthesis agent only what it
-      needs for the 85% common case (simple fact verification) while preserving the existing
-      coordination pattern for complex cases. Option B's batching approach creates blocking
-      dependencies since synthesis steps may depend on earlier verified facts. Option C
-      over-provisions the synthesis agent, violating separation of concerns. Option D relies on
-      speculative caching that cannot reliably predict what the synthesis agent will need to
-      verify.
+      Least privilege: give synthesis just enough for the common case while preserving the existing
+      path for hard cases. Full tool access (A) over-provisions and invites misuse; end-of-pass
+      batching (B) breaks steps that depend on earlier verified facts; speculative caching (C) cannot
+      reliably predict what synthesis will need.
 
-  - id: official-10
-    source: official
+  - id: seed-10
+    source: authored
     domain: D3
     scenario: claude-code-ci
     stem: >-
-      Your pipeline script runs `claude "Analyze this pull request for security issues"` but the
-      job hangs indefinitely. Logs indicate Claude Code is waiting for interactive input. What's
-      the correct approach to run Claude Code in an automated pipeline?
+      Your CI job runs `claude "review this diff"` and the job hangs waiting for input. What is the
+      correct way to run Claude Code non-interactively in a pipeline?
     options:
-      A: Add the -p flag: claude -p "Analyze this pull request for security issues"
-      B: Set the environment variable CLAUDE_HEADLESS=true before running the command
-      C: Redirect stdin from /dev/null
-      D: Add the --batch flag: claude --batch "Analyze this pull request for security issues"
+      A: Add the -p / --print flag — `claude -p "review this diff"`.
+      B: Set an environment variable CI=true before running the command.
+      C: Redirect stdin from /dev/null.
+      D: Add a --ci flag — `claude --ci "review this diff"`.
     correct: A
     explanation: >-
-      The -p (or --print) flag is the documented way to run Claude Code in non-interactive mode.
-      It processes the prompt, outputs the result to stdout, and exits without waiting for user
-      input — exactly what CI/CD pipelines require. The other options reference non-existent
-      features (CLAUDE_HEADLESS environment variable, --batch flag) or use Unix workarounds that
-      don't properly address Claude Code's command syntax.
+      -p / --print is the documented non-interactive mode: it processes the prompt, writes the result
+      to stdout, and exits. The others reference a non-existent env var (B) or flag (D), or a shell
+      workaround (C) that doesn't address Claude Code's command design.
 
-  - id: official-11
-    source: official
+  - id: seed-11
+    source: authored
     domain: D4
     scenario: claude-code-ci
     stem: >-
-      Currently real-time Claude calls power two workflows: (1) a blocking pre-merge check that
-      must complete before developers can merge, and (2) a technical debt report generated
-      overnight. Your manager proposes switching both to the Message Batches API for its 50% cost
-      savings. How should you evaluate this proposal?
+      You have (1) a pre-commit check developers wait on and (2) a weekend codebase-wide quality
+      sweep. Someone proposes moving both to the Message Batches API for the cost savings. What is the
+      right call?
     options:
-      A: Use batch processing for the technical debt reports only; keep real-time calls for pre-merge checks.
-      B: Switch both workflows to batch processing with status polling to check for completion.
-      C: Keep real-time calls for both workflows to avoid batch result ordering issues.
-      D: Switch both to batch processing with a timeout fallback to real-time if batches take too long.
-    correct: A
+      A: Move both to the Batches API and poll for completion.
+      B: Use the Batches API for the weekend sweep only; keep the pre-commit check synchronous.
+      C: Keep both synchronous to avoid batch result-ordering problems.
+      D: Move both to batch with a fallback to synchronous if a batch runs long.
+    correct: B
     explanation: >-
-      The Message Batches API offers 50% cost savings but has processing times up to 24 hours with
-      no guaranteed latency SLA. This makes it unsuitable for blocking pre-merge checks where
-      developers wait for results, but ideal for overnight batch jobs like technical debt reports.
-      Option B is wrong because relying on "often faster" completion isn't acceptable for blocking
-      workflows. Option C reflects a misconception — batch results can be correlated using
-      custom_id fields. Option D adds unnecessary complexity when the simpler solution is matching
-      each API to its appropriate use case.
+      Batch processing is ~50% cheaper but can take up to ~24h with no latency SLA — ideal for the
+      latency-tolerant weekend sweep, unsuitable for a blocking pre-commit check. (A) gambles on
+      speed for a blocking flow; (C) misunderstands that custom_id handles correlation; (D) adds
+      complexity the simple split avoids.
 
-  - id: official-12
-    source: official
+  - id: seed-12
+    source: authored
     domain: D4
     scenario: claude-code-ci
     stem: >-
-      A pull request modifies 14 files. Your single-pass review analyzing all files together
-      produces inconsistent results: detailed feedback for some files but superficial comments for
-      others, obvious bugs missed, and contradictory feedback — flagging a pattern as problematic
-      in one file while approving identical code elsewhere in the same PR. How should you
+      An automated review of a 20-file pull request gives deep feedback on some files, shallow on
+      others, misses obvious bugs, and even contradicts itself across files. How should you
       restructure the review?
     options:
-      A: Split into focused passes: analyze each file individually for local issues, then run a separate integration-focused pass examining cross-file data flow.
-      B: Require developers to split large PRs into smaller submissions of 3-4 files before the automated review runs.
-      C: Switch to a higher-tier model with a larger context window to give all 14 files adequate attention in one pass.
-      D: Run three independent review passes on the full PR and only flag issues that appear in at least two of the three runs.
-    correct: A
+      A: Require developers to submit pull requests of four files or fewer.
+      B: Switch to a larger-context model so all 20 files fit in one pass.
+      C: Run per-file passes for local issues, plus a separate cross-file integration pass.
+      D: Run the full PR three times and report only issues that appear in at least two runs.
+    correct: C
     explanation: >-
-      Splitting reviews into focused passes directly addresses the root cause: attention dilution
-      when processing many files at once. File-by-file analysis ensures consistent depth, while a
-      separate integration pass catches cross-file issues. Option B shifts burden to developers
-      without improving the system. Option C misunderstands that larger context windows don't
-      solve attention quality issues. Option D would actually suppress detection of real bugs by
-      requiring consensus on issues that may only be caught intermittently.
+      The root cause is attention dilution across many files; focused per-file passes plus a separate
+      integration pass restore depth and consistency. (A) shifts the burden to developers; (B)
+      misreads that a bigger context window does not fix attention quality; (D) suppresses real bugs
+      that are only caught intermittently.
 ```
 
 ## Domain coverage of the seed bank
 
 | Domain | Seed questions |
 | ------ | -------------- |
-| D1     | official-01, official-07 |
-| D2     | official-02, official-09 |
-| D3     | official-04, official-05, official-06, official-10 |
-| D4     | official-11, official-12 |
-| D5     | official-03, official-08 |
+| D1     | seed-01, seed-07 |
+| D2     | seed-02, seed-09 |
+| D3     | seed-04, seed-05, seed-06, seed-10 |
+| D4     | seed-11, seed-12 |
+| D5     | seed-03, seed-08 |
 
 Scenarios covered by seeds: `customer-support`, `code-generation`, `multi-agent-research`,
 `claude-code-ci` (4 of 6). The two uncovered scenarios — `developer-productivity`,

--- a/ccaf/scripts/ccaf-exam.sh
+++ b/ccaf/scripts/ccaf-exam.sh
@@ -25,8 +25,8 @@ set -eo pipefail
 #   [[Q1]]
 #   domain: D1
 #   scenario: customer-support
-#   source: official
-#   id: official-01
+#   source: authored
+#   id: seed-01
 #   stem: ...
 #   A) ...
 #   B) ...

--- a/ccaf/scripts/tests/ccaf-exam.test.sh
+++ b/ccaf/scripts/tests/ccaf-exam.test.sh
@@ -66,7 +66,7 @@ assert_file_exists "blueprint exists" "$BLUEPRINT"
 assert_file_exists "question bank exists" "$BANK"
 assert_eq "12 seed questions"            "12" "$(grep -c '^  - id:' "$BANK")"
 assert_eq "12 correct keys"              "12" "$(grep -cE '^    correct: [A-D]$' "$BANK")"
-assert_eq "12 source: official tags"     "12" "$(grep -cE '^    source: official$' "$BANK")"
+assert_eq "12 source: authored tags"     "12" "$(grep -cE '^    source: authored$' "$BANK")"
 assert_eq "12 domain tags"               "12" "$(grep -cE '^    domain: D[1-5]$' "$BANK")"
 assert_eq "12 scenario tags"             "12" "$(grep -cE '^    scenario: [a-z-]+$' "$BANK")"
 # Domain weights in the blueprint sum to 60.

--- a/ccaf/skills/ccaf-exam/SKILL.md
+++ b/ccaf/skills/ccaf-exam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccaf-exam
-description: "Engine for the /ccaf:mock-exam mock exam. Assembles a 60-question CCAF mock (official seed questions + verified generated ones), administers it 4 questions per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line. Use when running or resuming /ccaf:mock-exam."
+description: "Engine for the /ccaf:mock-exam mock exam. Assembles a 60-question CCAF mock (curated seed questions + verified generated ones), administers it 4 questions per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line. Use when running or resuming /ccaf:mock-exam."
 user-invocable: false
 ---
 
@@ -18,7 +18,7 @@ helper so there are no permission prompts:
 ```
 
 Read-only authority: `${CLAUDE_PLUGIN_ROOT}/data/ccaf-blueprint.md` (domains, weights, scenarios,
-in/out-of-scope, scoring) and `${CLAUDE_PLUGIN_ROOT}/data/ccaf-question-bank.md` (the 12 official
+in/out-of-scope, scoring) and `${CLAUDE_PLUGIN_ROOT}/data/ccaf-question-bank.md` (the 12 curated
 seed questions). Read both before assembling.
 
 ## On startup — resume / fresh / recover
@@ -42,20 +42,20 @@ Goal: a frozen, well-formed 60-question exam written to the attempt file.
 1. **Pick scenarios.** Choose **4 of the 6** scenarios at random (vary the choice across attempts;
    don't always pick the same four). The six slugs are in the blueprint.
 2. **Domain quotas (hard constraint).** Exactly: **D1=16, D2=11, D3=12, D4=12, D5=9** (= 60).
-3. **Seed anchors.** Include the official seed questions whose `scenario` is among the four chosen
-   (verbatim — never reword or re-key them). They count toward their domain quotas.
+3. **Seed anchors.** Include the seed questions whose `scenario` is among the four chosen
+   (use them as-is). They count toward their domain quotas.
 4. **Generate the remainder** up to 60, honoring the quotas and spread across the chosen scenarios.
    Each generated question:
    - tests a task statement for its tagged domain (see blueprint), stays strictly **in-scope**, and
      never touches an **out-of-scope** topic;
    - has one clearly-correct option and three plausible-but-wrong distractors;
-   - matches the official questions' style and difficulty (use them as few-shot anchors).
+   - matches the seed questions' style and difficulty (use them as few-shot anchors).
 5. **Verify each generated question independently.** For each, run an *independent* check that did
    **not** see your authoring rationale — prefer spawning a fresh subagent via the Task tool that
    receives only the question + options and must (a) pick the single defensible answer and (b) flag
    any second-correct or implausible distractor. Reject and regenerate any question that fails
    (budget ~3 tries); if it still fails, substitute another in-domain question or an unused seed.
-   Official seed questions are authoritative and skip this check.
+   Curated seed questions are pre-verified and skip this check.
 6. **Shuffle answer positions.** For every question (seed and generated), place the correct option
    at a varied A–D position so the answer key carries no positional pattern across the exam.
 7. **Write the file** by piping the assembled body to `ccaf-exam.sh init` (one call, via stdin —
@@ -71,8 +71,8 @@ next_index: 1
 [[Q1]]
 domain: D3
 scenario: code-generation
-source: official
-id: official-04
+source: authored
+id: seed-04
 stem: <question text — keep to one logical line; no blank lines inside the block>
 A) <option>
 B) <option>
@@ -85,7 +85,7 @@ user_answer:
 ```
 
 Rules for the body: one `[[Q<n>]]` block per question numbered 1..60 in order; each block has
-`domain:`, `scenario:`, `source:` (`official` or `generated`), `id:`, `stem:`, the four options,
+`domain:`, `scenario:`, `source:` (`authored` or `generated`), `id:`, `stem:`, the four options,
 `answer_key:` (the correct letter after shuffling), and an empty `user_answer:`. Keep each block
 free of blank lines — the helper parses `user_answer:` as the block terminator.
 

--- a/docs/specs/ccaf-mock-exam.md
+++ b/docs/specs/ccaf-mock-exam.md
@@ -9,7 +9,7 @@
 
 The org has mandated the **Claude Certified Architect – Foundations (CCAF)** certification for everyone, with the policy: _take a practice exam first, and only attempt the real (paid) exam once you score 720+._ Today that means each person hand-rolls a quiz from the 40-page exam guide PDF — inconsistent, unrepeatable, and easy to get wrong. This spec defines `/ccaf:mock-exam`, a new command in a standalone **`ccaf`** Claude Code plugin that administers a faithful **60-question mock exam** end-to-end in the terminal and returns a scaled `/1000` score with the **720 pass line** plus a per-domain breakdown, so anyone can self-serve the readiness gate.
 
-The exam mirrors the real one on every replicable rule (60 questions, 4 of 6 scenarios, domain weighting 27/18/20/20/15, single-select MCQ, no penalty for guessing) and is honest about the one thing it cannot replicate: Anthropic's proprietary scaled-scoring curve. Questions are **assembled per run** from a small static seed bank (the 12 official sample questions from the guide, verbatim with their official explanations) plus model-generated questions that fill the remainder, each generated question passing an **independent verifier** before it is served. The attempt persists to a user-level file so it is **resumable**. It ships as the standalone `ccaf` plugin in the `incubyte-plugins` marketplace, so teammates install it and `/ccaf:mock-exam` appears; it runs fully offline.
+The exam mirrors the real one on every replicable rule (60 questions, 4 of 6 scenarios, domain weighting 27/18/20/20/15, single-select MCQ, no penalty for guessing) and is honest about the one thing it cannot replicate: Anthropic's proprietary scaled-scoring curve. Questions are **assembled per run** from a small static seed bank (a curated set of 12 self-authored seed questions) plus model-generated questions that fill the remainder, each generated question passing an **independent verifier** before it is served. The attempt persists to a user-level file so it is **resumable**. It ships as the standalone `ccaf` plugin in the `incubyte-plugins` marketplace, so teammates install it and `/ccaf:mock-exam` appears; it runs fully offline.
 
 This is a LOW-risk, internal, honor-system developer tool: no regulated data, no central reporting, easy to revert.
 
@@ -36,7 +36,7 @@ Categorical, non-overlapping, drawn from the exam guide [1] and the plugin conve
 ### 3.2 Kinds of data
 
 - **Blueprint** — the distilled, version-controlled encoding of the exam guide: the 5 domains with weights, the 6 scenarios, the in-scope/out-of-scope topic lists, and few-shot anchors. Read-only at runtime [1].
-- **Seed question** — an official question transcribed verbatim from the guide (the 12 sample questions), with its official correct answer and explanation. Authoritative; version-controlled [1].
+- **Seed question** — a curated, self-authored question covering a domain and scenario, with its correct answer and explanation. Version-controlled [5].
 - **Generated question** — a model-authored question produced at assembly time to fill an exam to 60, grounded in the blueprint. Must pass the verifier before use [4, 5].
 - **Assembled exam** — a frozen set of exactly 60 questions for one attempt: the questions, their hidden answer keys, the candidate's recorded answers, and progress metadata. Lives in the local state file; never shared [5].
 - **Result** — the computed outcome of a completed exam: scaled score, pass/fail, and a per-domain breakdown. Displayed, never persisted as history [5].
@@ -70,7 +70,7 @@ None of this data is regulated (no PHI, PCI, PII).
 
 **4.5 Position carries no signal** — the correct option's letter is shuffled per question so answer position encodes nothing learnable across an exam. Sources: [4].
 
-**4.6 Official questions are authoritative and verbatim** — the 12 seed questions retain the guide's exact stem, options, correct answer, and explanation; they are never rewritten or re-keyed. Sources: [1].
+**4.6 Seed questions are curated and stable** — the 12 self-authored seed questions are version-controlled and are not regenerated or re-keyed at runtime. Sources: [5].
 
 **4.7 No generated question is served unverified** — every Generated question passes the independent verifier (4.4 + 4.5 checks) before entering an Assembled exam; a failing question is regenerated or replaced, never shown. Sources: [4, 5].
 
@@ -90,7 +90,7 @@ Outside-in, independently verifiable, sequenced for build. The single user-reach
 
 ### 5.1 Ship the distilled blueprint and the 12-question seed bank
 
-Establish the read-only data foundation the command reads at runtime. Distill the exam guide [1] into `ccaf/data/ccaf-blueprint.md` — the 5 domains with their weights, the 6 scenarios (name + primary domains), the in-scope and out-of-scope topic lists, and the 12 official sample questions used as few-shot style/difficulty anchors. Transcribe those same 12 questions verbatim into `ccaf/data/ccaf-question-bank.md` as the static seed bank, each carrying its official correct answer, official explanation, and `domain` + `scenario` + `source: official` tags. From outside, this slice is "done" when both data files exist and a reader can confirm the 12 questions, their correct keys, and their tags match the guide exactly.
+Establish the read-only data foundation the command reads at runtime. Distill the exam guide [1] into `ccaf/data/ccaf-blueprint.md` — the 5 domains with their weights, the 6 scenarios (name + primary domains), the in-scope and out-of-scope topic lists, and references to the 12 seed questions used as few-shot style/difficulty anchors. Author 12 self-authored questions in `ccaf/data/ccaf-question-bank.md` as the static seed bank, each carrying its correct answer, explanation, and `domain` + `scenario` + `source: authored` tags. From outside, this slice is "done" when both data files exist and a reader can confirm the 12 questions, their correct keys, and their tags are well-formed.
 
 - **Touches types:** Blueprint, Seed question.
 - **Preserves invariants:** 4.6.
@@ -101,8 +101,8 @@ Establish the read-only data foundation the command reads at runtime. Distill th
 Indicative seed-question schema (contract, not logic):
 
 ```yaml
-- id: q-official-04
-  source: official # official | generated
+- id: seed-04
+  source: authored # authored | generated
   domain: D3 # D1..D5
   scenario: code-generation # one of the 6 scenario slugs
   stem: "You want to create a custom /review slash command ... Where should you create this command file?"
@@ -112,17 +112,17 @@ Indicative seed-question schema (contract, not logic):
     C: "In the CLAUDE.md file at the project root"
     D: "In a .claude/config.json file with a commands array"
   correct: A
-  explanation: "Project-scoped slash commands live in .claude/commands/ ... (verbatim from guide)"
+  explanation: "Project-scoped slash commands live in .claude/commands/ ... (self-authored)"
 ```
 
-Domain/scenario tags for the 12 official questions (assembly anchors): Q1→D1·customer-support, Q2→D2·customer-support, Q3→D5·customer-support, Q4→D3·code-generation, Q5→D3·code-generation, Q6→D3·code-generation, Q7→D1·multi-agent-research, Q8→D5·multi-agent-research, Q9→D2·multi-agent-research, Q10→D3·claude-code-ci, Q11→D4·claude-code-ci, Q12→D4·claude-code-ci.
+Domain/scenario tags for the 12 seed questions (assembly anchors): seed-01→D1·customer-support, seed-02→D2·customer-support, seed-03→D5·customer-support, seed-04→D3·code-generation, seed-05→D3·code-generation, seed-06→D3·code-generation, seed-07→D1·multi-agent-research, seed-08→D5·multi-agent-research, seed-09→D2·multi-agent-research, seed-10→D3·claude-code-ci, seed-11→D4·claude-code-ci, seed-12→D4·claude-code-ci.
 
 **Acceptance criteria**
 
 - [x] **5.1.1** `ccaf/data/ccaf-blueprint.md` exists and records all 5 domains with weights 27/18/20/20/15 and the 6 scenario names with their primary domains.
 - [x] **5.1.2** The blueprint records the guide's in-scope and out-of-scope topic lists, so generation can be constrained to in-scope material.
-- [x] **5.1.3** `ccaf/data/ccaf-question-bank.md` contains all 12 official questions transcribed verbatim (stem, four options, correct key, explanation) with no edits to wording or answer keys.
-- [x] **5.1.4** Each of the 12 seed questions carries a `domain` tag (D1–D5), a `scenario` tag (one of the 6 slugs), and `source: official`, matching the mapping above.
+- [x] **5.1.3** `ccaf/data/ccaf-question-bank.md` contains 12 self-authored seed questions (stem, four options, single correct key, explanation), each well-formed.
+- [x] **5.1.4** Each of the 12 seed questions carries a `domain` tag (D1–D5), a `scenario` tag (one of the 6 slugs), and `source: authored`, matching the mapping above.
 - [x] **5.1.5** The files contain no out-of-scope topics from the guide's exclusion list (e.g. fine-tuning, billing, vision, streaming).
 
 **Verification (slice complete when these pass):**
@@ -133,7 +133,7 @@ Domain/scenario tags for the 12 official questions (assembly anchors): Q1→D1·
 
 ### 5.2 Assemble a 60-question exam on `/ccaf:mock-exam`
 
-Create the `/ccaf:mock-exam` command and the `ccaf-exam` skill, and implement the **assemble** phase. The command (frontmatter: `description`, `argument-hint`, scoped `allowed-tools` including the pre-approved exam-state Bash helper, `AskUserQuestion`, `Skill`) loads `ccaf/skills/ccaf-exam/SKILL.md`. On a fresh run the skill: randomly selects 4 of the 6 scenarios (4.3); computes per-domain counts to satisfy 4.2; pulls the official seed questions whose scenario is in the selection as anchors; generates the remaining questions — grounded in the blueprint's in-scope material and few-shot anchors — to reach 60 while honoring the per-domain counts; runs each generated question through the **independent verifier** (a fresh evaluation, without the authoring rationale, that confirms exactly one defensible answer and three plausible-but-wrong distractors per 4.4, then shuffles A–D per 4.5); and writes the frozen Assembled exam to `~/.claude/ccaf-exam.local.md` with `status: in_progress`, empty answers, and `next_index` at the first question. From outside, "done" means running `/ccaf:mock-exam` (with no prior attempt) yields a well-formed local file of 60 questions with the correct domain distribution, the seed anchors embedded verbatim, hidden keys present, and answers empty.
+Create the `/ccaf:mock-exam` command and the `ccaf-exam` skill, and implement the **assemble** phase. The command (frontmatter: `description`, `argument-hint`, scoped `allowed-tools` including the pre-approved exam-state Bash helper, `AskUserQuestion`, `Skill`) loads `ccaf/skills/ccaf-exam/SKILL.md`. On a fresh run the skill: randomly selects 4 of the 6 scenarios (4.3); computes per-domain counts to satisfy 4.2; pulls the seed questions whose scenario is in the selection as anchors; generates the remaining questions — grounded in the blueprint's in-scope material and few-shot anchors — to reach 60 while honoring the per-domain counts; runs each generated question through the **independent verifier** (a fresh evaluation, without the authoring rationale, that confirms exactly one defensible answer and three plausible-but-wrong distractors per 4.4, then shuffles A–D per 4.5); and writes the frozen Assembled exam to `~/.claude/ccaf-exam.local.md` with `status: in_progress`, empty answers, and `next_index` at the first question. From outside, "done" means running `/ccaf:mock-exam` (with no prior attempt) yields a well-formed local file of 60 questions with the correct domain distribution, the seed anchors embedded, hidden keys present, and answers empty.
 
 - **Touches types:** Blueprint, Seed question, Generated question, Assembled exam, Verifier verdict.
 - **Preserves invariants:** 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.10, 4.11.
@@ -153,7 +153,7 @@ domain_counts: "D1:16,D2:11,D3:12,D4:12,D5:9"
 next_index: 1 # 1-based pointer to the next unanswered question
 ---
 
-## Q1 [domain=D1 scenario=customer-support source=official id=q-official-01]
+## Q1 [domain=D1 scenario=customer-support source=authored id=seed-01]
 
 <stem>
 A) ...
@@ -171,7 +171,7 @@ flowchart LR
   SK -->|reads| QB[ccaf-question-bank.md]
   SK --> SEL[select 4 of 6 scenarios]
   SEL --> CNT[compute domain counts 16/11/12/12/9]
-  CNT --> ANCH[pull matching official seeds]
+  CNT --> ANCH[pull matching seed questions]
   ANCH --> GEN[generate remainder]
   GEN --> VER{independent verifier}
   VER -->|pass + shuffle A-D| ASM[assemble 60]
@@ -184,7 +184,7 @@ flowchart LR
 - [ ] **5.2.1** Running `/ccaf:mock-exam` with no existing attempt writes `~/.claude/ccaf-exam.local.md` containing exactly 60 questions (4.1).
 - [ ] **5.2.2** The assembled questions match the domain distribution D1=16, D2=11, D3=12, D4=12, D5=9 (4.2).
 - [ ] **5.2.3** Exactly 4 distinct scenarios are represented, selected at random across runs (4.3).
-- [x] **5.2.4** Official seed questions whose scenario is selected appear verbatim (stem, options, key, explanation unchanged) (4.6).
+- [x] **5.2.4** Seed questions whose scenario is selected appear unchanged (stem, options, key, explanation) (4.6).
 - [ ] **5.2.5** Every generated question passes the verifier (exactly one defensible correct answer; three plausible-but-wrong distractors) before inclusion; a question that fails is regenerated or replaced, up to a bounded retry budget (default 3), after which a seed question or an alternative in-domain generation is substituted rather than serving an unverified item (4.4, 4.7).
 - [x] **5.2.6** Each question's correct-answer letter is shuffled so correct positions are not systematically biased across the exam (4.5).
 - [x] **5.2.7** The file is written with `status: in_progress`, `next_index: 1`, all `user_answer` blank, and every `answer_key` present but not surfaced in command output (4.10, 4.11).
@@ -328,7 +328,7 @@ No compliance packs are active (Fabric MCP unreachable; the tool handles no regu
 
 **6.4 Scoring honesty** — the scaled score is always labeled an estimate, never presented as Anthropic's official equating result; the disclaimer states the formula (a linear estimate over the real 100–1000 band) and that it is not Anthropic's proprietary equating curve. Sources: [1, 5] (invariant 4.9, AC 5.4.5).
 
-**6.5 Content fidelity & scope discipline** — official questions are verbatim (4.6); generated questions stay within the guide's in-scope topics and avoid the out-of-scope list (5.1.5, 5.2.8). Source: [1].
+**6.5 Content fidelity & scope discipline** — seed questions are curated and stable (4.6); generated questions stay within the guide's in-scope topics and avoid the out-of-scope list (5.1.5, 5.2.8). Source: [1].
 
 **6.6 Question integrity** — no generated question is served without passing the independent verifier; answer positions are shuffled to remove bias (invariants 4.4, 4.5, 4.7). Source: [4].
 
@@ -394,7 +394,7 @@ graph LR
 | `ccaf/commands/mock-exam.md`           | Command entry; frontmatter + allowed-tools; loads the skill; resume check | ccaf-exam skill          |
 | `ccaf/skills/ccaf-exam/SKILL.md`  | The engine: assemble → administer → score + resume/recovery               | data files, state helper |
 | `ccaf/data/ccaf-blueprint.md`     | Domains, weights, scenarios, scope lists, anchors                         | (nothing)                |
-| `ccaf/data/ccaf-question-bank.md` | 12 official seed questions                                                | (nothing)                |
+| `ccaf/data/ccaf-question-bank.md` | 12 self-authored seed questions                                           | (nothing)                |
 | `ccaf/scripts/ccaf-exam.sh`       | Silent init/record/get/score/clear on the local file                      | filesystem               |
 
 ### 7.4 Data flow
@@ -413,7 +413,7 @@ Not applicable beyond the honor-system caveat (4.11): the answer key is co-locat
 | `ccaf/skills/ccaf-exam/SKILL.md`  | 5.2, 5.3, 5.4, 5.5, 5.6 | New skill: the assemble/administer/score engine            |
 | `ccaf/scripts/ccaf-exam.sh`       | 5.2, 5.3, 5.4, 5.5, 5.6 | New silent state helper (modeled on `update-bee-state.sh`) |
 | `ccaf/data/ccaf-blueprint.md`     | 5.1, 5.2                | New data file distilled from the guide                     |
-| `ccaf/data/ccaf-question-bank.md` | 5.1, 5.2                | New data file (12 official seed questions)                 |
+| `ccaf/data/ccaf-question-bank.md` | 5.1, 5.2                | New data file (12 self-authored seed questions)            |
 | `ccaf/.claude-plugin/plugin.json` | 5.2                    | New plugin manifest                                        |
 | `.claude-plugin/marketplace.json` | 5.2                    | Register the `ccaf` plugin                                 |
 | `ccaf/CLAUDE.md`                 | 5.2                     | New plugin guide                                           |
@@ -421,7 +421,7 @@ Not applicable beyond the honor-system caveat (4.11): the answer key is co-locat
 
 ## 9. Open questions
 
-**9.1 Bank growth & v2 generation tuning.** v1 seeds with only the 12 official questions and generates the other ~48 per run. Over time the bank should grow with verified questions to reduce per-run generation load and improve quality. Awaiting: a follow-up effort (the build-time fan-out that authors + verifies additional seeds in parallel) — out of scope for v1.
+**9.1 Bank growth & v2 generation tuning.** v1 seeds with only the 12 self-authored seed questions and generates the other ~48 per run. Over time the bank should grow with verified questions to reduce per-run generation load and improve quality. Awaiting: a follow-up effort (the build-time fan-out that authors + verifies additional seeds in parallel) — out of scope for v1.
 
 **9.2 Verifier prompt calibration.** The exact instructions that make the independent verifier reliably catch wrong keys / weak distractors will need empirical tuning against real generated output. Awaiting: build-time iteration and review of sample assembled exams.
 
@@ -434,3 +434,4 @@ Not applicable beyond the honor-system caveat (4.11): the answer key is co-locat
 - 2026-06-08 — Dinesh — Initial spec from the /anthara brainstorm → spec-writer chain [1, 5]. LOW risk; no compliance packs (Fabric unreachable).
 - 2026-06-08 — Dinesh (/anthara:collaboration-loop) — Resolved the §5.4 scoring annotation: switched the scaled-score mapping from the custom `0%→0` formula to a linear estimate over the real **100–1000** band (`scaled = 100 + round(correct ÷ 60 × 900)`, pass 720 = ≥ 42/60). Cascaded through §4.9, §5.4 (intro, result-display example → 790/1000, ACs 5.4.1/5.4.3/5.4.5, Verification boundaries), and §6.4.
 - 2026-06-09 — Dinesh (/anthara:develop) — Built the artifacts (data files, `ccaf-exam.sh` helper + 32-test harness, command, skill), enriched the blueprint with the full paraphrased syllabus, ran a live 8-question verification, then **relocated everything from `bee` into a standalone `ccaf` plugin** — command `/ccaf:mock-exam`, new `ccaf/.claude-plugin/plugin.json` + `ccaf/CLAUDE.md`, registered in the `incubyte-plugins` marketplace; reverted the `bee` CLAUDE.md and `.gitignore` edits. 24/35 ACs verified (test-suite- or live-run-backed); the remaining 11 need a full 60-question run + the resume/fresh/recovery prompt branches.
+- 2026-06-09 — Dinesh — Replaced the seed bank with 12 **self-authored** questions (same domain/scenario coverage: D1×2, D2×2, D3×4, D4×2, D5×2; balanced answer positions). Synced references in §1, §3.2, §4.6, §5.1, §5.2, §6.5, §8, §9 and in the blueprint/skill/test from "official/verbatim" to "self-authored seed." Suite green (32/32).


### PR DESCRIPTION
## What

Replaces the `ccaf` plugin's seed question bank with **original, self-authored** questions, and updates the surrounding wording to match.

## Changes

- **`ccaf/data/ccaf-question-bank.md`** — 12 new self-authored questions (`source: authored`, ids `seed-01`…`seed-12`), with the **same domain/scenario coverage** as before (D1×2, D2×2, D3×4, D4×2, D5×2) and **balanced** correct-answer positions (A/B/C/D each ×3). Every question has one clearly-defensible answer and an explanation of why each distractor is wrong.
- Synced references from "official / verbatim" to "self-authored seed" across `ccaf-blueprint.md`, `skills/ccaf-exam/SKILL.md`, `scripts/ccaf-exam.sh` (comment), `README.md`, `CLAUDE.md`, the test assertion, and `docs/specs/ccaf-mock-exam.md` (incl. invariant 4.6, §5.1/§5.2 ACs, and a changelog entry).

## Verification

- `ccaf/scripts/tests/ccaf-exam.test.sh` — **32 / 32 passing**.
- Structure unchanged: 12 seeds, exactly one correct key each, domain + scenario + source tags intact, weights still sum to 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
