### PR TITLE
fix(bee): repair agent frontmatter YAML and set license to MIT

### DIFF
--- a/bee/.claude-plugin/plugin.json
+++ b/bee/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bee",
   "description": "Bee — a spec-driven TDD workflow navigator for AI-assisted development. Guides developers through the right level of process: triage, spec, architecture, TDD planning, execution, verification, and review.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Incubyte"
   },

--- a/bee/.claude-plugin/plugin.json
+++ b/bee/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
   "author": {
     "name": "Incubyte"
   },
-  "license": "Proprietary"
+  "license": "MIT"
 }

--- a/bee/agents/architecture-advisor.md
+++ b/bee/agents/architecture-advisor.md
@@ -1,33 +1,34 @@
 ---
 name: architecture-advisor
-description: Use this agent to evaluate architecture options when the task warrants a decision. Most tasks just follow existing patterns. Includes YAGNI check. Use for FEATURE and EPIC workflows after spec confirmation.
+description: |
+  Use this agent to evaluate architecture options when the task warrants a decision. Most tasks just follow existing patterns. Includes YAGNI check. Use for FEATURE and EPIC workflows after spec confirmation.
 
-<example>
-Context: Spec is confirmed and the codebase has an existing MVC pattern
-user: "The spec is ready. What architecture should we use?"
-assistant: "The codebase uses MVC and this fits. No architecture change needed."
-<commentary>
-Most tasks follow existing patterns. Architecture-advisor confirms the existing pattern rather than introducing unnecessary complexity.
-</commentary>
-</example>
+  <example>
+  Context: Spec is confirmed and the codebase has an existing MVC pattern
+  user: "The spec is ready. What architecture should we use?"
+  assistant: "The codebase uses MVC and this fits. No architecture change needed."
+  <commentary>
+  Most tasks follow existing patterns. Architecture-advisor confirms the existing pattern rather than introducing unnecessary complexity.
+  </commentary>
+  </example>
 
-<example>
-Context: New subsystem that doesn't fit existing patterns
-user: "We need to add a real-time event processing pipeline"
-assistant: "This requires an architecture decision. Let me evaluate options."
-<commentary>
-New subsystem with event-driven needs. Architecture-advisor presents options with tradeoffs for the developer to choose.
-</commentary>
-</example>
+  <example>
+  Context: New subsystem that doesn't fit existing patterns
+  user: "We need to add a real-time event processing pipeline"
+  assistant: "This requires an architecture decision. Let me evaluate options."
+  <commentary>
+  New subsystem with event-driven needs. Architecture-advisor presents options with tradeoffs for the developer to choose.
+  </commentary>
+  </example>
 
-<example>
-Context: Feature has distinct read and write concerns
-user: "Build a reporting dashboard with separate write and query paths"
-assistant: "This has distinct read/write sides. Let me check if CQRS makes sense."
-<commentary>
-CQRS candidate. Architecture-advisor runs the preliminary CQRS check before pattern selection.
-</commentary>
-</example>
+  <example>
+  Context: Feature has distinct read and write concerns
+  user: "Build a reporting dashboard with separate write and query paths"
+  assistant: "This has distinct read/write sides. Let me check if CQRS makes sense."
+  <commentary>
+  CQRS candidate. Architecture-advisor runs the preliminary CQRS check before pattern selection.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/architecture-impl-advisor.md
+++ b/bee/agents/architecture-impl-advisor.md
@@ -1,33 +1,34 @@
 ---
 name: architecture-impl-advisor
-description: Use this agent to evaluate architecture for spec-driven development (SDD). Reads the spec and codebase, evaluates across 6 dimensions (Simplicity, Cohesion, Decoupling, Evolvability, Testability, Readability), and recommends the simplest starting architecture with evolution triggers. Decoupled from TDD planners — output is consumed by slice-coder and slice-tester.
+description: |
+  Use this agent to evaluate architecture for spec-driven development (SDD). Reads the spec and codebase, evaluates across 6 dimensions (Simplicity, Cohesion, Decoupling, Evolvability, Testability, Readability), and recommends the simplest starting architecture with evolution triggers. Decoupled from TDD planners — output is consumed by slice-coder and slice-tester.
 
-<example>
-Context: SDD workflow on a new feature in an existing Express API
-user: "Evaluate architecture for this spec"
-assistant: "The codebase uses MVC with Express. This feature fits the existing pattern. Recommending MVC with feature-scoped files."
-<commentary>
-Existing pattern detected. Advisor confirms it rather than introducing unnecessary complexity. Outputs structure and evolution triggers for the slice-coder.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow on a new feature in an existing Express API
+  user: "Evaluate architecture for this spec"
+  assistant: "The codebase uses MVC with Express. This feature fits the existing pattern. Recommending MVC with feature-scoped files."
+  <commentary>
+  Existing pattern detected. Advisor confirms it rather than introducing unnecessary complexity. Outputs structure and evolution triggers for the slice-coder.
+  </commentary>
+  </example>
 
-<example>
-Context: Greenfield project with a CLI tool spec
-user: "What architecture should I use for this CLI?"
-assistant: "Simple feature folders. Co-locate commands with their logic. Extract shared utilities only when you see the third duplicate."
-<commentary>
-Greenfield + simple scope. Advisor picks the simplest starting point and provides evolution triggers for when complexity grows.
-</commentary>
-</example>
+  <example>
+  Context: Greenfield project with a CLI tool spec
+  user: "What architecture should I use for this CLI?"
+  assistant: "Simple feature folders. Co-locate commands with their logic. Extract shared utilities only when you see the third duplicate."
+  <commentary>
+  Greenfield + simple scope. Advisor picks the simplest starting point and provides evolution triggers for when complexity grows.
+  </commentary>
+  </example>
 
-<example>
-Context: SDD workflow on a feature with complex domain logic
-user: "This spec has business rules around pricing tiers and discounts"
-assistant: "The domain logic is rich enough to warrant boundaries. Recommending MVC with a service layer — evolve to onion if the domain grows further."
-<commentary>
-Complexity warrants more structure than simple, but not full onion yet. Advisor recommends the evolutionary middle ground.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow on a feature with complex domain logic
+  user: "This spec has business rules around pricing tiers and discounts"
+  assistant: "The domain logic is rich enough to warrant boundaries. Recommending MVC with a service layer — evolve to onion if the domain grows further."
+  <commentary>
+  Complexity warrants more structure than simple, but not full onion yet. Advisor recommends the evolutionary middle ground.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/architecture-test-writer.md
+++ b/bee/agents/architecture-test-writer.md
@@ -1,24 +1,25 @@
 ---
 name: architecture-test-writer
-description: Use this agent to generate runnable ArchUnit-style boundary tests from a confirmed architecture assessment report. Produces passing tests for healthy boundaries and intentionally failing tests for architecture leaks.
+description: |
+  Use this agent to generate runnable ArchUnit-style boundary tests from a confirmed architecture assessment report. Produces passing tests for healthy boundaries and intentionally failing tests for architecture leaks.
 
-<example>
-Context: Architecture assessment is confirmed and boundary tests are needed
-user: "Generate boundary tests from the architecture assessment"
-assistant: "I'll create ArchUnit-style tests that document good boundaries and flag leaks."
-<commentary>
-Post-assessment step. Turns architecture findings into runnable tests that enforce boundaries.
-</commentary>
-</example>
+  <example>
+  Context: Architecture assessment is confirmed and boundary tests are needed
+  user: "Generate boundary tests from the architecture assessment"
+  assistant: "I'll create ArchUnit-style tests that document good boundaries and flag leaks."
+  <commentary>
+  Post-assessment step. Turns architecture findings into runnable tests that enforce boundaries.
+  </commentary>
+  </example>
 
-<example>
-Context: /bee:architect command delegates to this agent after developer confirmation
-user: "The assessment looks good. Generate the boundary tests."
-assistant: "I'll produce passing tests for healthy boundaries and failing tests for detected leaks."
-<commentary>
-Part of the architect workflow. Generates tests that can be added to CI to prevent future boundary violations.
-</commentary>
-</example>
+  <example>
+  Context: /bee:architect command delegates to this agent after developer confirmation
+  user: "The assessment looks good. Generate the boundary tests."
+  assistant: "I'll produce passing tests for healthy boundaries and failing tests for detected leaks."
+  <commentary>
+  Part of the architect workflow. Generates tests that can be added to CI to prevent future boundary violations.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/browser-verifier.md
+++ b/bee/agents/browser-verifier.md
@@ -1,24 +1,25 @@
 ---
 name: browser-verifier
-description: Use this agent to verify a running app in the browser — checks acceptance criteria, console errors, runtime exceptions, and visual state via browser MCP tools. Supports Claude-in-Chrome (primary) and chrome-devtools-mcp (fallback). Operates in dev mode (failures only) or test mode (full report with screenshots).
+description: |
+  Use this agent to verify a running app in the browser — checks acceptance criteria, console errors, runtime exceptions, and visual state via browser MCP tools. Supports Claude-in-Chrome (primary) and chrome-devtools-mcp (fallback). Operates in dev mode (failures only) or test mode (full report with screenshots).
 
-<example>
-Context: Feature is deployed to dev server and needs browser-based verification
-user: "Verify the login page works against the spec"
-assistant: "I'll open the app in Chrome and verify each acceptance criterion."
-<commentary>
-Browser-based verification against spec. Opens the running app, interacts with it, checks console for errors, takes screenshots.
-</commentary>
-</example>
+  <example>
+  Context: Feature is deployed to dev server and needs browser-based verification
+  user: "Verify the login page works against the spec"
+  assistant: "I'll open the app in Chrome and verify each acceptance criterion."
+  <commentary>
+  Browser-based verification against spec. Opens the running app, interacts with it, checks console for errors, takes screenshots.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee browser-test command delegates to this agent for each spec
-user: "Run browser tests for the checkout flow"
-assistant: "I'll verify each acceptance criterion in the browser."
-<commentary>
-Delegated by the browser-test command. Verifies ACs one by one in a real browser.
-</commentary>
-</example>
+  <example>
+  Context: Bee browser-test command delegates to this agent for each spec
+  user: "Run browser tests for the checkout flow"
+  assistant: "I'll verify each acceptance criterion in the browser."
+  <commentary>
+  Delegated by the browser-test command. Verifies ACs one by one in a real browser.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/context-gatherer.md
+++ b/bee/agents/context-gatherer.md
@@ -1,33 +1,34 @@
 ---
 name: context-gatherer
-description: Use this agent to read a codebase and understand patterns, conventions, and the area being changed. Run before planning. Use for any task beyond TRIVIAL.
+description: |
+  Use this agent to read a codebase and understand patterns, conventions, and the area being changed. Run before planning. Use for any task beyond TRIVIAL.
 
-<example>
-Context: Bee build workflow needs to understand the codebase before speccing a feature
-user: "Add user authentication to the app"
-assistant: "Let me scan the codebase first to understand what we're working with."
-<commentary>
-Feature-sized task. Context-gatherer runs before spec-builder to understand existing patterns, test infrastructure, and the change area.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow needs to understand the codebase before speccing a feature
+  user: "Add user authentication to the app"
+  assistant: "Let me scan the codebase first to understand what we're working with."
+  <commentary>
+  Feature-sized task. Context-gatherer runs before spec-builder to understand existing patterns, test infrastructure, and the change area.
+  </commentary>
+  </example>
 
-<example>
-Context: Developer asks for a code review and the codebase needs scanning
-user: "Review the code quality of the payments module"
-assistant: "I'll analyze the codebase structure first."
-<commentary>
-Review workflow needs codebase context. Context-gatherer provides the structural understanding that review agents build on.
-</commentary>
-</example>
+  <example>
+  Context: Developer asks for a code review and the codebase needs scanning
+  user: "Review the code quality of the payments module"
+  assistant: "I'll analyze the codebase structure first."
+  <commentary>
+  Review workflow needs codebase context. Context-gatherer provides the structural understanding that review agents build on.
+  </commentary>
+  </example>
 
-<example>
-Context: Architecture assessment needs codebase analysis
-user: "Assess the architecture of this project"
-assistant: "Let me read the codebase to understand the current architecture."
-<commentary>
-Architecture commands delegate to context-gatherer for initial codebase analysis before deeper assessment.
-</commentary>
-</example>
+  <example>
+  Context: Architecture assessment needs codebase analysis
+  user: "Assess the architecture of this project"
+  assistant: "Let me read the codebase to understand the current architecture."
+  <commentary>
+  Architecture commands delegate to context-gatherer for initial codebase analysis before deeper assessment.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan

--- a/bee/agents/design-agent.md
+++ b/bee/agents/design-agent.md
@@ -1,33 +1,34 @@
 ---
 name: design-agent
-description: Use this agent to produce a design brief for UI-involved projects. For existing design systems, it reads and documents what exists. For greenfield projects, it interviews the developer and proposes a cohesive design direction.
+description: |
+  Use this agent to produce a design brief for UI-involved projects. For existing design systems, it reads and documents what exists. For greenfield projects, it interviews the developer and proposes a cohesive design direction.
 
-<example>
-Context: Context-gatherer detected Tailwind and shadcn components in the project
-user: "Add a dashboard page to the app"
-assistant: "I see UI signals in the codebase. Let me produce a design brief from the existing design system."
-<commentary>
-UI-involved feature with an existing design system. Design-agent extracts and documents the system so downstream agents produce visually consistent output.
-</commentary>
-</example>
+  <example>
+  Context: Context-gatherer detected Tailwind and shadcn components in the project
+  user: "Add a dashboard page to the app"
+  assistant: "I see UI signals in the codebase. Let me produce a design brief from the existing design system."
+  <commentary>
+  UI-involved feature with an existing design system. Design-agent extracts and documents the system so downstream agents produce visually consistent output.
+  </commentary>
+  </example>
 
-<example>
-Context: Greenfield project with no design system but UI components needed
-user: "Build a landing page for our new SaaS product"
-assistant: "No design system detected. I'll interview you about visual preferences to create a design brief."
-<commentary>
-Greenfield UI work. Design-agent runs in interview mode to establish a design direction before speccing begins.
-</commentary>
-</example>
+  <example>
+  Context: Greenfield project with no design system but UI components needed
+  user: "Build a landing page for our new SaaS product"
+  assistant: "No design system detected. I'll interview you about visual preferences to create a design brief."
+  <commentary>
+  Greenfield UI work. Design-agent runs in interview mode to establish a design direction before speccing begins.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow detects UI-involved task during context gathering
-user: "Add a settings page with user profile editing"
-assistant: "UI work detected. Let me document the design system first."
-<commentary>
-The build orchestrator triggers the design-agent when context-gatherer reports UI-involved: yes. The brief constrains all downstream UI decisions.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow detects UI-involved task during context gathering
+  user: "Add a settings page with user profile editing"
+  assistant: "UI work detected. Let me document the design system first."
+  <commentary>
+  The build orchestrator triggers the design-agent when context-gatherer reports UI-involved: yes. The brief constrains all downstream UI decisions.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan

--- a/bee/agents/discovery.md
+++ b/bee/agents/discovery.md
@@ -1,33 +1,34 @@
 ---
 name: discovery
-description: Use this agent as a PM persona that interviews users and produces a client-shareable PRD. Works standalone via /bee:discover or internally via /bee:sdd. Explores the why, what, and how of a requirement before speccing.
+description: |
+  Use this agent as a PM persona that interviews users and produces a client-shareable PRD. Works standalone via /bee:discover or internally via /bee:sdd. Explores the why, what, and how of a requirement before speccing.
 
-<example>
-Context: User has a vague idea and needs requirements exploration
-user: "I want to build a reporting dashboard for our clients"
-assistant: "Let me start a discovery session to understand the requirements before we spec."
-<commentary>
-Vague requirement with high decision density. Discovery agent interviews to produce a PRD before speccing begins.
-</commentary>
-</example>
+  <example>
+  Context: User has a vague idea and needs requirements exploration
+  user: "I want to build a reporting dashboard for our clients"
+  assistant: "Let me start a discovery session to understand the requirements before we spec."
+  <commentary>
+  Vague requirement with high decision density. Discovery agent interviews to produce a PRD before speccing begins.
+  </commentary>
+  </example>
 
-<example>
-Context: User provides meeting notes or a transcript to synthesize
-user: "Here are the notes from our product meeting about the new onboarding flow"
-assistant: "I'll synthesize these notes into a structured PRD."
-<commentary>
-Rich input provided. Discovery agent switches to synthesis mode — extracts key decisions and identifies gaps.
-</commentary>
-</example>
+  <example>
+  Context: User provides meeting notes or a transcript to synthesize
+  user: "Here are the notes from our product meeting about the new onboarding flow"
+  assistant: "I'll synthesize these notes into a structured PRD."
+  <commentary>
+  Rich input provided. Discovery agent switches to synthesis mode — extracts key decisions and identifies gaps.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow identifies high decision density during triage
-user: "Build a multi-tenant billing system"
-assistant: "This has a lot of unknowns. Let me run a discovery session first."
-<commentary>
-EPIC-sized task with many decisions to make. The orchestrator invokes discovery before speccing to reduce ambiguity.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow identifies high decision density during triage
+  user: "Build a multi-tenant billing system"
+  assistant: "This has a lot of unknowns. Let me run a discovery session first."
+  <commentary>
+  EPIC-sized task with many decisions to make. The orchestrator invokes discovery before speccing to reduce ambiguity.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan

--- a/bee/agents/domain-language-extractor.md
+++ b/bee/agents/domain-language-extractor.md
@@ -1,24 +1,25 @@
 ---
 name: domain-language-extractor
-description: Use this agent to extract domain vocabulary from README, docs, the company's website, and code naming patterns. Compares domain language against code structure to find vocabulary drift and boundary violations.
+description: |
+  Use this agent to extract domain vocabulary from README, docs, the company's website, and code naming patterns. Compares domain language against code structure to find vocabulary drift and boundary violations.
 
-<example>
-Context: Architecture assessment needs domain language analysis
-user: "Assess the architecture of this project"
-assistant: "I'll extract the domain vocabulary and compare it against the code structure."
-<commentary>
-Part of the /bee:architect workflow. Extracts how the product describes itself and compares against code naming.
-</commentary>
-</example>
+  <example>
+  Context: Architecture assessment needs domain language analysis
+  user: "Assess the architecture of this project"
+  assistant: "I'll extract the domain vocabulary and compare it against the code structure."
+  <commentary>
+  Part of the /bee:architect workflow. Extracts how the product describes itself and compares against code naming.
+  </commentary>
+  </example>
 
-<example>
-Context: Developer wants to understand domain vocabulary drift
-user: "Are our code names aligned with our domain language?"
-assistant: "I'll compare your documentation language against code naming patterns."
-<commentary>
-Standalone domain analysis. Finds where code naming diverges from how the business describes concepts.
-</commentary>
-</example>
+  <example>
+  Context: Developer wants to understand domain vocabulary drift
+  user: "Are our code names aligned with our domain language?"
+  assistant: "I'll compare your documentation language against code naming patterns."
+  <commentary>
+  Standalone domain analysis. Finds where code naming diverges from how the business describes concepts.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/onboard.md
+++ b/bee/agents/onboard.md
@@ -1,24 +1,25 @@
 ---
 name: onboard
-description: Use this agent to analyze a codebase and deliver an interactive onboarding walkthrough adapted to the developer's role, experience, and focus area. Use when a developer is joining an existing project.
+description: |
+  Use this agent to analyze a codebase and deliver an interactive onboarding walkthrough adapted to the developer's role, experience, and focus area. Use when a developer is joining an existing project.
 
-<example>
-Context: New developer joining an existing project
-user: "I'm new to this codebase. Help me get oriented."
-assistant: "I'll walk you through the project — architecture, entry points, domain concepts, and how to run tests."
-<commentary>
-New team member onboarding. Agent adapts walkthrough to the developer's role and experience level.
-</commentary>
-</example>
+  <example>
+  Context: New developer joining an existing project
+  user: "I'm new to this codebase. Help me get oriented."
+  assistant: "I'll walk you through the project — architecture, entry points, domain concepts, and how to run tests."
+  <commentary>
+  New team member onboarding. Agent adapts walkthrough to the developer's role and experience level.
+  </commentary>
+  </example>
 
-<example>
-Context: Developer switching to a different part of the codebase
-user: "I need to understand the payments module"
-assistant: "I'll give you an interactive walkthrough of the payments module."
-<commentary>
-Focused onboarding for a specific module. Agent analyzes and walks through the relevant area.
-</commentary>
-</example>
+  <example>
+  Context: Developer switching to a different part of the codebase
+  user: "I need to understand the payments module"
+  assistant: "I'll give you an interactive walkthrough of the payments module."
+  <commentary>
+  Focused onboarding for a specific module. Agent analyzes and walks through the relevant area.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan

--- a/bee/agents/programmer.md
+++ b/bee/agents/programmer.md
@@ -1,24 +1,25 @@
 ---
 name: programmer
-description: Use this agent to write code for a TDD plan slice — writes failing tests, makes them pass, refactors. Follows strict RED-GREEN-REFACTOR one test at a time. Use after TDD plan is reviewed and approved.
+description: |
+  Use this agent to write code for a TDD plan slice — writes failing tests, makes them pass, refactors. Follows strict RED-GREEN-REFACTOR one test at a time. Use after TDD plan is reviewed and approved.
 
-<example>
-Context: TDD plan for a feature slice has been reviewed and approved
-user: "Execute the TDD plan at docs/specs/feature-slice-1-tdd-plan.md"
-assistant: "I'll execute the TDD plan step by step — one test at a time, RED-GREEN-REFACTOR."
-<commentary>
-Post-planning execution. The programmer works through the TDD plan mechanically, writing quality code guided by preloaded skills.
-</commentary>
-</example>
+  <example>
+  Context: TDD plan for a feature slice has been reviewed and approved
+  user: "Execute the TDD plan at docs/specs/feature-slice-1-tdd-plan.md"
+  assistant: "I'll execute the TDD plan step by step — one test at a time, RED-GREEN-REFACTOR."
+  <commentary>
+  Post-planning execution. The programmer works through the TDD plan mechanically, writing quality code guided by preloaded skills.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow transitions from planning to execution
-user: "TDD plan reviewed. Let's build."
-assistant: "Starting execution of the TDD plan for this slice."
-<commentary>
-Delegated by the build orchestrator after TDD plan review. The programmer returns when the slice is complete.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow transitions from planning to execution
+  user: "TDD plan reviewed. Let's build."
+  assistant: "Starting execution of the TDD plan for this slice."
+  <commentary>
+  Delegated by the build orchestrator after TDD plan review. The programmer returns when the slice is complete.
+  </commentary>
+  </example>
 
 model: sonnet
 color: green

--- a/bee/agents/qc-planner.md
+++ b/bee/agents/qc-planner.md
@@ -1,24 +1,25 @@
 ---
 name: qc-planner
-description: Use this agent to synthesize review agent outputs into a prioritized test plan. Scores hotspots, inventories existing tests, assesses testability, and produces a fixed-format plan.
+description: |
+  Use this agent to synthesize review agent outputs into a prioritized test plan. Scores hotspots, inventories existing tests, assesses testability, and produces a fixed-format plan.
 
-<example>
-Context: Review agents have completed their analysis and results need synthesis
-user: "Synthesize the review results into a test plan"
-assistant: "I'll score hotspots, inventory existing tests, and produce a prioritized test plan."
-<commentary>
-Post-review synthesis. QC planner takes behavioral, test, and coupling analysis and produces actionable test priorities.
-</commentary>
-</example>
+  <example>
+  Context: Review agents have completed their analysis and results need synthesis
+  user: "Synthesize the review results into a test plan"
+  assistant: "I'll score hotspots, inventory existing tests, and produce a prioritized test plan."
+  <commentary>
+  Post-review synthesis. QC planner takes behavioral, test, and coupling analysis and produces actionable test priorities.
+  </commentary>
+  </example>
 
-<example>
-Context: /bee:qc command delegates to this agent after spawning review agents
-user: "Run quality coverage analysis on the codebase"
-assistant: "I'll analyze hotspots and produce a prioritized test plan."
-<commentary>
-Part of the qc workflow. Receives analysis from review agents and synthesizes into a plan at docs/specs/qc-plan.md.
-</commentary>
-</example>
+  <example>
+  Context: /bee:qc command delegates to this agent after spawning review agents
+  user: "Run quality coverage analysis on the codebase"
+  assistant: "I'll analyze hotspots and produce a prioritized test plan."
+  <commentary>
+  Part of the qc workflow. Receives analysis from review agents and synthesizes into a plan at docs/specs/qc-plan.md.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/quick-fix.md
+++ b/bee/agents/quick-fix.md
@@ -1,33 +1,34 @@
 ---
 name: quick-fix
-description: Use this agent when the orchestrator classifies a task as TRIVIAL — typos, config changes, obvious one-liners. Makes the fix and runs tests.
+description: |
+  Use this agent when the orchestrator classifies a task as TRIVIAL — typos, config changes, obvious one-liners. Makes the fix and runs tests.
 
-<example>
-Context: User reports a typo in a README file
-user: "Fix the typo in README.md where it says 'recieve' instead of 'receive'"
-assistant: "This is a quick fix. Let me handle it."
-<commentary>
-Trivial fix — single character change, no spec or plan needed. Quick-fix agent handles it end-to-end.
-</commentary>
-</example>
+  <example>
+  Context: User reports a typo in a README file
+  user: "Fix the typo in README.md where it says 'recieve' instead of 'receive'"
+  assistant: "This is a quick fix. Let me handle it."
+  <commentary>
+  Trivial fix — single character change, no spec or plan needed. Quick-fix agent handles it end-to-end.
+  </commentary>
+  </example>
 
-<example>
-Context: User needs a config value changed
-user: "Change the port in the config from 3000 to 8080"
-assistant: "Simple config change. I'll fix it and run tests."
-<commentary>
-Config change classified as TRIVIAL by the orchestrator. Quick-fix makes the change and verifies tests pass.
-</commentary>
-</example>
+  <example>
+  Context: User needs a config value changed
+  user: "Change the port in the config from 3000 to 8080"
+  assistant: "Simple config change. I'll fix it and run tests."
+  <commentary>
+  Config change classified as TRIVIAL by the orchestrator. Quick-fix makes the change and verifies tests pass.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow triages a task as TRIVIAL
-user: "Add the missing semicolon in utils.ts line 42"
-assistant: "Got it — trivial fix. I'll use the quick-fix agent."
-<commentary>
-One-liner fix. The orchestrator delegates to quick-fix for immediate resolution.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow triages a task as TRIVIAL
+  user: "Add the missing semicolon in utils.ts line 42"
+  assistant: "Got it — trivial fix. I'll use the quick-fix agent."
+  <commentary>
+  One-liner fix. The orchestrator delegates to quick-fix for immediate resolution.
+  </commentary>
+  </example>
 
 model: inherit
 color: green

--- a/bee/agents/recap.md
+++ b/bee/agents/recap.md
@@ -1,15 +1,16 @@
 ---
 name: recap
-description: Use this agent after SDD completes to walk the developer through what was built — files changed, core logic, tests written, architecture decisions.
+description: |
+  Use this agent after SDD completes to walk the developer through what was built — files changed, core logic, tests written, architecture decisions.
 
-<example>
-Context: SDD workflow just completed and developer wants a walkthrough
-user: "Walk me through what we just built"
-assistant: "I'll recap the feature — what changed, the core logic, tests, and architecture decisions."
-<commentary>
-After SDD finishes, the recap agent reads the artifacts and produces a structured, scannable walkthrough so the developer understands the code they now own.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow just completed and developer wants a walkthrough
+  user: "Walk me through what we just built"
+  assistant: "I'll recap the feature — what changed, the core logic, tests, and architecture decisions."
+  <commentary>
+  After SDD finishes, the recap agent reads the artifacts and produces a structured, scannable walkthrough so the developer understands the code they now own.
+  </commentary>
+  </example>
 
 model: inherit
 color: green

--- a/bee/agents/review-ai-ergonomics.md
+++ b/bee/agents/review-ai-ergonomics.md
@@ -1,15 +1,16 @@
 ---
 name: review-ai-ergonomics
-description: Use this agent to review code for how well LLMs can work with it — context window friendliness, explicitness, module boundaries, test-as-spec, naming, and documentation quality. Use as part of the multi-agent review.
+description: |
+  Use this agent to review code for how well LLMs can work with it — context window friendliness, explicitness, module boundaries, test-as-spec, naming, and documentation quality. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "How LLM-friendly is this codebase?"
-assistant: "I'll analyze context window friendliness, explicitness, and module boundaries."
-<commentary>
-Part of the multi-agent review workflow. Evaluates how well the code supports AI-assisted development.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "How LLM-friendly is this codebase?"
+  assistant: "I'll analyze context window friendliness, explicitness, and module boundaries."
+  <commentary>
+  Part of the multi-agent review workflow. Evaluates how well the code supports AI-assisted development.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-behavioral.md
+++ b/bee/agents/review-behavioral.md
@@ -1,15 +1,16 @@
 ---
 name: review-behavioral
-description: Use this agent to analyze git history to find hotspots (high-churn + high-complexity files) and temporal coupling (files that change together). Use as part of the multi-agent review.
+description: |
+  Use this agent to analyze git history to find hotspots (high-churn + high-complexity files) and temporal coupling (files that change together). Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Find the hotspots in this codebase"
-assistant: "I'll analyze git history for high-churn, high-complexity files and temporal coupling."
-<commentary>
-Part of the multi-agent review workflow. Uses git history to identify where problems cluster.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Find the hotspots in this codebase"
+  assistant: "I'll analyze git history for high-churn, high-complexity files and temporal coupling."
+  <commentary>
+  Part of the multi-agent review workflow. Uses git history to identify where problems cluster.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-code-quality.md
+++ b/bee/agents/review-code-quality.md
@@ -1,15 +1,16 @@
 ---
 name: review-code-quality
-description: Use this agent to review code against clean code principles — SRP, DRY, YAGNI, naming, small functions, error handling, dependency direction. Use as part of the multi-agent review.
+description: |
+  Use this agent to review code against clean code principles — SRP, DRY, YAGNI, naming, small functions, error handling, dependency direction. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Review the code quality of the orders module"
-assistant: "I'll analyze the code against clean code principles."
-<commentary>
-Part of the multi-agent review workflow. Focuses on SRP, DRY, YAGNI, naming, and dependency direction.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Review the code quality of the orders module"
+  assistant: "I'll analyze the code against clean code principles."
+  <commentary>
+  Part of the multi-agent review workflow. Focuses on SRP, DRY, YAGNI, naming, and dependency direction.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-coupling.md
+++ b/bee/agents/review-coupling.md
@@ -1,15 +1,16 @@
 ---
 name: review-coupling
-description: Use this agent to analyze structural coupling — import dependencies, afferent/efferent coupling, change amplifiers, and decoupling opportunities. Use as part of the multi-agent review.
+description: |
+  Use this agent to analyze structural coupling — import dependencies, afferent/efferent coupling, change amplifiers, and decoupling opportunities. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Analyze the coupling in the payments module"
-assistant: "I'll analyze import dependencies and identify change amplifiers."
-<commentary>
-Part of the multi-agent review workflow. Focuses on structural coupling and decoupling opportunities.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Analyze the coupling in the payments module"
+  assistant: "I'll analyze import dependencies and identify change amplifiers."
+  <commentary>
+  Part of the multi-agent review workflow. Focuses on structural coupling and decoupling opportunities.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-org-standards.md
+++ b/bee/agents/review-org-standards.md
@@ -1,15 +1,16 @@
 ---
 name: review-org-standards
-description: Use this agent to review code against the target project's CLAUDE.md conventions and rules. Checks project-specific patterns, naming, architecture, and any custom standards. Use as part of the multi-agent review.
+description: |
+  Use this agent to review code against the target project's CLAUDE.md conventions and rules. Checks project-specific patterns, naming, architecture, and any custom standards. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Check if the code follows our project conventions"
-assistant: "I'll review against the CLAUDE.md conventions and project-specific rules."
-<commentary>
-Part of the multi-agent review workflow. Checks code against project-specific standards from CLAUDE.md.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Check if the code follows our project conventions"
+  assistant: "I'll review against the CLAUDE.md conventions and project-specific rules."
+  <commentary>
+  Part of the multi-agent review workflow. Checks code against project-specific standards from CLAUDE.md.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-team-practices.md
+++ b/bee/agents/review-team-practices.md
@@ -1,15 +1,16 @@
 ---
 name: review-team-practices
-description: Use this agent to review team practices — commit message quality and PR review substance. Identifies rubber-stamp reviews and low-quality commit messages. Use as part of the multi-agent review.
+description: |
+  Use this agent to review team practices — commit message quality and PR review substance. Identifies rubber-stamp reviews and low-quality commit messages. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Review our team practices"
-assistant: "I'll analyze commit message quality and PR review substance."
-<commentary>
-Part of the multi-agent review workflow. Identifies team health signals from git history and PR reviews.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Review our team practices"
+  assistant: "I'll analyze commit message quality and PR review substance."
+  <commentary>
+  Part of the multi-agent review workflow. Identifies team health signals from git history and PR reviews.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/review-tests.md
+++ b/bee/agents/review-tests.md
@@ -1,15 +1,16 @@
 ---
 name: review-tests
-description: Use this agent to review test quality — vanity test detection, assertion quality, mocking discipline, behavior-based testing, isolation, naming, frontend-specific checks, and coverage gaps. Use as part of the multi-agent review.
+description: |
+  Use this agent to review test quality — vanity test detection, assertion quality, mocking discipline, behavior-based testing, isolation, naming, frontend-specific checks, and coverage gaps. Use as part of the multi-agent review.
 
-<example>
-Context: /bee:review command spawns specialist review agents
-user: "Review the test quality in this project"
-assistant: "I'll analyze test naming, isolation, coverage gaps, and behavior-based testing."
-<commentary>
-Part of the multi-agent review workflow. Focuses on whether tests describe behavior, not implementation.
-</commentary>
-</example>
+  <example>
+  Context: /bee:review command spawns specialist review agents
+  user: "Review the test quality in this project"
+  assistant: "I'll analyze test naming, isolation, coverage gaps, and behavior-based testing."
+  <commentary>
+  Part of the multi-agent review workflow. Focuses on whether tests describe behavior, not implementation.
+  </commentary>
+  </example>
 
 model: inherit
 color: magenta

--- a/bee/agents/reviewer.md
+++ b/bee/agents/reviewer.md
@@ -1,24 +1,25 @@
 ---
 name: reviewer
-description: Use this agent to review the complete body of work after all slices are done. Risk-aware ship recommendation. Use after all slices are verified complete.
+description: |
+  Use this agent to review the complete body of work after all slices are done. Risk-aware ship recommendation. Use after all slices are verified complete.
 
-<example>
-Context: All slices verified and the feature is ready for final review
-user: "All slices are done and verified. Do the final review."
-assistant: "I'll review the complete body of work — spec coverage, code quality, test quality, and ship recommendation."
-<commentary>
-Final review after all slices pass verification. Reviewer looks at the whole picture, not individual slices.
-</commentary>
-</example>
+  <example>
+  Context: All slices verified and the feature is ready for final review
+  user: "All slices are done and verified. Do the final review."
+  assistant: "I'll review the complete body of work — spec coverage, code quality, test quality, and ship recommendation."
+  <commentary>
+  Final review after all slices pass verification. Reviewer looks at the whole picture, not individual slices.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow triggers final review automatically
-user: "Feature complete. What's the ship recommendation?"
-assistant: "Running the final review with risk-aware assessment."
-<commentary>
-Automatic final step in the build workflow. Produces a ship/no-ship recommendation based on risk level.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow triggers final review automatically
+  user: "Feature complete. What's the ship recommendation?"
+  assistant: "Running the final review with risk-aware assessment."
+  <commentary>
+  Automatic final step in the build workflow. Produces a ship/no-ship recommendation based on risk level.
+  </commentary>
+  </example>
 
 model: inherit
 color: yellow

--- a/bee/agents/sdd-verifier.md
+++ b/bee/agents/sdd-verifier.md
@@ -1,24 +1,25 @@
 ---
 name: sdd-verifier
-description: Use this agent to verify a completed SDD slice — tests pass, test quality assessed, criteria met, patterns followed. Risk-aware. Replaces TDD plan completion check with test quality assessment (branch coverage, assertion quality, boundary testing) since tests are written after code in SDD.
+description: |
+  Use this agent to verify a completed SDD slice — tests pass, test quality assessed, criteria met, patterns followed. Risk-aware. Replaces TDD plan completion check with test quality assessment (branch coverage, assertion quality, boundary testing) since tests are written after code in SDD.
 
-<example>
-Context: An SDD slice has been coded and tested, needs verification
-user: "Slice 1 is coded and tested. Verify it."
-assistant: "I'll run tests, assess test quality, and validate acceptance criteria."
-<commentary>
-Post-execution verification for SDD. Runs the full test suite, checks test quality (branch coverage, assertion quality), and reports pass/fail.
-</commentary>
-</example>
+  <example>
+  Context: An SDD slice has been coded and tested, needs verification
+  user: "Slice 1 is coded and tested. Verify it."
+  assistant: "I'll run tests, assess test quality, and validate acceptance criteria."
+  <commentary>
+  Post-execution verification for SDD. Runs the full test suite, checks test quality (branch coverage, assertion quality), and reports pass/fail.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee SDD workflow automatically verifies after slice-tester completes
-user: "Slice-tester finished. Run the verifier."
-assistant: "Running SDD verification — tests, quality assessment, AC coverage."
-<commentary>
-Automatic verification step in the SDD workflow. The key difference from TDD verifier: instead of checking TDD plan completion, it assesses test quality since tests were written after code.
-</commentary>
-</example>
+  <example>
+  Context: Bee SDD workflow automatically verifies after slice-tester completes
+  user: "Slice-tester finished. Run the verifier."
+  assistant: "Running SDD verification — tests, quality assessment, AC coverage."
+  <commentary>
+  Automatic verification step in the SDD workflow. The key difference from TDD verifier: instead of checking TDD plan completion, it assesses test quality since tests were written after code.
+  </commentary>
+  </example>
 
 model: inherit
 color: yellow

--- a/bee/agents/slice-coder.md
+++ b/bee/agents/slice-coder.md
@@ -1,24 +1,25 @@
 ---
 name: slice-coder
-description: Use this agent to write production code for one spec slice in the SDD workflow. Receives the spec, architecture recommendation, and context — writes all production code for the slice's acceptance criteria. Does NOT write tests.
+description: |
+  Use this agent to write production code for one spec slice in the SDD workflow. Receives the spec, architecture recommendation, and context — writes all production code for the slice's acceptance criteria. Does NOT write tests.
 
-<example>
-Context: SDD workflow, architecture confirmed as MVC, slice 1 has 3 ACs
-user: "Write the production code for slice 1"
-assistant: "I'll implement all 3 ACs following the MVC structure. Starting with the route, then service, then model."
-<commentary>
-Slice-coder builds production code guided by the spec and architecture, not by failing tests. It writes testable code by design.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow, architecture confirmed as MVC, slice 1 has 3 ACs
+  user: "Write the production code for slice 1"
+  assistant: "I'll implement all 3 ACs following the MVC structure. Starting with the route, then service, then model."
+  <commentary>
+  Slice-coder builds production code guided by the spec and architecture, not by failing tests. It writes testable code by design.
+  </commentary>
+  </example>
 
-<example>
-Context: SDD workflow, simple feature folders, slice 2 has 2 ACs
-user: "Implement slice 2 — user profile validation"
-assistant: "I'll write the validation logic in the user feature folder with clear input/output boundaries."
-<commentary>
-Follows the architecture recommendation. Keeps functions small with clear interfaces so the slice-tester can test without heavy mocking.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow, simple feature folders, slice 2 has 2 ACs
+  user: "Implement slice 2 — user profile validation"
+  assistant: "I'll write the validation logic in the user feature folder with clear input/output boundaries."
+  <commentary>
+  Follows the architecture recommendation. Keeps functions small with clear interfaces so the slice-tester can test without heavy mocking.
+  </commentary>
+  </example>
 
 model: sonnet
 color: green

--- a/bee/agents/slice-tester.md
+++ b/bee/agents/slice-tester.md
@@ -1,24 +1,25 @@
 ---
 name: slice-tester
-description: Use this agent to write tests for completed production code in the SDD workflow. Reads production code with adversarial eyes, assesses testability, makes small testability refactors if needed, writes tests that verify each AC, and runs the full suite.
+description: |
+  Use this agent to write tests for completed production code in the SDD workflow. Reads production code with adversarial eyes, assesses testability, makes small testability refactors if needed, writes tests that verify each AC, and runs the full suite.
 
-<example>
-Context: SDD workflow, slice-coder just completed slice 1 with 3 ACs
-user: "Write tests for slice 1"
-assistant: "I'll read the production code, assess testability, then write tests for each AC."
-<commentary>
-Slice-tester reads the code the slice-coder wrote, checks that it's testable, writes tests, and runs them. Separate agent ensures tests aren't skipped in flow state.
-</commentary>
-</example>
+  <example>
+  Context: SDD workflow, slice-coder just completed slice 1 with 3 ACs
+  user: "Write tests for slice 1"
+  assistant: "I'll read the production code, assess testability, then write tests for each AC."
+  <commentary>
+  Slice-tester reads the code the slice-coder wrote, checks that it's testable, writes tests, and runs them. Separate agent ensures tests aren't skipped in flow state.
+  </commentary>
+  </example>
 
-<example>
-Context: Production code has a hardcoded HTTP client that can't be injected
-user: "Test the API integration feature"
-assistant: "The HTTP client is hardcoded. I'll extract it as a parameter — a small testability refactor — then write the tests."
-<commentary>
-Small testability refactor allowed: extracting a dependency as a parameter. The tester runs existing tests after the refactor to confirm nothing broke.
-</commentary>
-</example>
+  <example>
+  Context: Production code has a hardcoded HTTP client that can't be injected
+  user: "Test the API integration feature"
+  assistant: "The HTTP client is hardcoded. I'll extract it as a parameter — a small testability refactor — then write the tests."
+  <commentary>
+  Small testability refactor allowed: extracting a dependency as a parameter. The tester runs existing tests after the refactor to confirm nothing broke.
+  </commentary>
+  </example>
 
 model: sonnet
 color: yellow

--- a/bee/agents/spec-builder.md
+++ b/bee/agents/spec-builder.md
@@ -1,33 +1,34 @@
 ---
 name: spec-builder
-description: Use this agent to interview the developer and build a spec. Depth adapts to task size and risk. Use for FEATURE and EPIC workflows after context gathering.
+description: |
+  Use this agent to interview the developer and build a spec. Depth adapts to task size and risk. Use for FEATURE and EPIC workflows after context gathering.
 
-<example>
-Context: Bee build workflow has gathered context and is ready to spec a feature
-user: "Add user authentication with email and password"
-assistant: "Let me interview you to build a spec for the authentication feature."
-<commentary>
-FEATURE-sized task. Spec-builder interviews the developer, writes testable acceptance criteria, and saves to docs/specs/.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow has gathered context and is ready to spec a feature
+  user: "Add user authentication with email and password"
+  assistant: "Let me interview you to build a spec for the authentication feature."
+  <commentary>
+  FEATURE-sized task. Spec-builder interviews the developer, writes testable acceptance criteria, and saves to docs/specs/.
+  </commentary>
+  </example>
 
-<example>
-Context: EPIC task needs to be sliced into vertical increments
-user: "Build a complete e-commerce checkout flow"
-assistant: "This is a large feature. I'll interview you and break it into vertical slices with clear acceptance criteria."
-<commentary>
-EPIC-sized task. Spec-builder conducts a thorough interview, slices vertically, and produces a multi-slice spec.
-</commentary>
-</example>
+  <example>
+  Context: EPIC task needs to be sliced into vertical increments
+  user: "Build a complete e-commerce checkout flow"
+  assistant: "This is a large feature. I'll interview you and break it into vertical slices with clear acceptance criteria."
+  <commentary>
+  EPIC-sized task. Spec-builder conducts a thorough interview, slices vertically, and produces a multi-slice spec.
+  </commentary>
+  </example>
 
-<example>
-Context: Discovery document exists and spec-builder should build on it
-user: "We finished discovery. Now let's write the spec for Phase 1."
-assistant: "I'll read the discovery doc and build a spec for Phase 1's capabilities."
-<commentary>
-Post-discovery speccing. Spec-builder reads the discovery document and specs only the requested phase.
-</commentary>
-</example>
+  <example>
+  Context: Discovery document exists and spec-builder should build on it
+  user: "We finished discovery. Now let's write the spec for Phase 1."
+  assistant: "I'll read the discovery doc and build a spec for Phase 1's capabilities."
+  <commentary>
+  Post-discovery speccing. Spec-builder reads the discovery document and specs only the requested phase.
+  </commentary>
+  </example>
 
 model: inherit
 color: cyan

--- a/bee/agents/tdd-coder.md
+++ b/bee/agents/tdd-coder.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-coder
-description: Use this agent as the "code" side of ping-pong TDD. It receives a failing test and writes the minimum production code to make it pass. Refactors after GREEN.
+description: |
+  Use this agent as the "code" side of ping-pong TDD. It receives a failing test and writes the minimum production code to make it pass. Refactors after GREEN.
 
-<example>
-Context: Ping-pong parent agent passes a failing test to the coder
-user: "Make this test pass: 'should create account with valid email' — Error: createAccount is not defined"
-assistant: "I'll write the minimum code to make this test pass."
-<commentary>
-Coder writes just enough production code to make the specific failing test pass, then refactors.
-</commentary>
-</example>
+  <example>
+  Context: Ping-pong parent agent passes a failing test to the coder
+  user: "Make this test pass: 'should create account with valid email' — Error: createAccount is not defined"
+  assistant: "I'll write the minimum code to make this test pass."
+  <commentary>
+  Coder writes just enough production code to make the specific failing test pass, then refactors.
+  </commentary>
+  </example>
 
-<example>
-Context: Test passes but coder sees refactoring opportunity
-user: "Test passed. Here's the current source. Refactor if needed."
-assistant: "I see duplication in the validation logic. I'll extract a shared validator."
-<commentary>
-After GREEN, the coder refactors while keeping all tests passing.
-</commentary>
-</example>
+  <example>
+  Context: Test passes but coder sees refactoring opportunity
+  user: "Test passed. Here's the current source. Refactor if needed."
+  assistant: "I see duplication in the validation logic. I'll extract a shared validator."
+  <commentary>
+  After GREEN, the coder refactors while keeping all tests passing.
+  </commentary>
+  </example>
 
 model: inherit
 color: green

--- a/bee/agents/tdd-ping-pong.md
+++ b/bee/agents/tdd-ping-pong.md
@@ -1,15 +1,16 @@
 ---
 name: tdd-ping-pong
-description: Use this agent to run ping-pong TDD on a spec. It orchestrates a test-writer and coder agent in alternating RED-GREEN-REFACTOR cycles, one test at a time, until all acceptance criteria are implemented.
+description: |
+  Use this agent to run ping-pong TDD on a spec. It orchestrates a test-writer and coder agent in alternating RED-GREEN-REFACTOR cycles, one test at a time, until all acceptance criteria are implemented.
 
-<example>
-Context: Developer wants to implement a spec using ping-pong TDD
-user: "Run ping-pong TDD on docs/specs/user-auth.md"
-assistant: "I'll read the spec and start the RED-GREEN cycle, one test at a time."
-<commentary>
-Parent agent reads the spec, identifies ACs, and orchestrates the ping-pong cycle between test-writer and coder.
-</commentary>
-</example>
+  <example>
+  Context: Developer wants to implement a spec using ping-pong TDD
+  user: "Run ping-pong TDD on docs/specs/user-auth.md"
+  assistant: "I'll read the spec and start the RED-GREEN cycle, one test at a time."
+  <commentary>
+  Parent agent reads the spec, identifies ACs, and orchestrates the ping-pong cycle between test-writer and coder.
+  </commentary>
+  </example>
 
 model: inherit
 color: yellow

--- a/bee/agents/tdd-planner-cqrs.md
+++ b/bee/agents/tdd-planner-cqrs.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-planner-cqrs
-description: Use this agent to generate a split TDD plan for CQRS architectures. Command side (behavior + events) and query side (projections + read models). One plan per slice. Use when architecture decision is CQRS.
+description: |
+  Use this agent to generate a split TDD plan for CQRS architectures. Command side (behavior + events) and query side (projections + read models). One plan per slice. Use when architecture decision is CQRS.
 
-<example>
-Context: Architecture-advisor recommended CQRS for a feature with distinct read/write paths
-user: "Architecture is CQRS. Generate the TDD plan."
-assistant: "I'll create a split TDD plan — command side first, then query side."
-<commentary>
-CQRS architecture. This planner generates separate plans for the command side (state changes) and query side (read models).
-</commentary>
-</example>
+  <example>
+  Context: Architecture-advisor recommended CQRS for a feature with distinct read/write paths
+  user: "Architecture is CQRS. Generate the TDD plan."
+  assistant: "I'll create a split TDD plan — command side first, then query side."
+  <commentary>
+  CQRS architecture. This planner generates separate plans for the command side (state changes) and query side (read models).
+  </commentary>
+  </example>
 
-<example>
-Context: Feature with a write-heavy command path and a read-optimized dashboard
-user: "Plan the TDD for the analytics pipeline with separate write and read models"
-assistant: "I'll generate a CQRS TDD plan with command-side behavior tests and query-side projection tests."
-<commentary>
-Distinct read/write concerns. CQRS planner coordinates command side, event bridge, and query side.
-</commentary>
-</example>
+  <example>
+  Context: Feature with a write-heavy command path and a read-optimized dashboard
+  user: "Plan the TDD for the analytics pipeline with separate write and read models"
+  assistant: "I'll generate a CQRS TDD plan with command-side behavior tests and query-side projection tests."
+  <commentary>
+  Distinct read/write concerns. CQRS planner coordinates command side, event bridge, and query side.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/tdd-planner-event-driven.md
+++ b/bee/agents/tdd-planner-event-driven.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-planner-event-driven
-description: Use this agent to generate a contract-first TDD plan for event-driven architectures. One plan per slice. Use when architecture decision is event-driven or message-based.
+description: |
+  Use this agent to generate a contract-first TDD plan for event-driven architectures. One plan per slice. Use when architecture decision is event-driven or message-based.
 
-<example>
-Context: Architecture-advisor recommended event-driven for a webhook processing feature
-user: "Architecture is event-driven. Generate the TDD plan."
-assistant: "I'll create a contract-first TDD plan starting with event schemas."
-<commentary>
-Event-driven architecture. This planner generates plans starting from event contracts, then producers, then consumers.
-</commentary>
-</example>
+  <example>
+  Context: Architecture-advisor recommended event-driven for a webhook processing feature
+  user: "Architecture is event-driven. Generate the TDD plan."
+  assistant: "I'll create a contract-first TDD plan starting with event schemas."
+  <commentary>
+  Event-driven architecture. This planner generates plans starting from event contracts, then producers, then consumers.
+  </commentary>
+  </example>
 
-<example>
-Context: Feature centered on async message processing
-user: "Plan the TDD for the notification queue processor"
-assistant: "I'll generate an event-driven TDD plan with contract-first approach."
-<commentary>
-Message-based feature. Planner ensures event contracts are defined first, then producer/consumer tests.
-</commentary>
-</example>
+  <example>
+  Context: Feature centered on async message processing
+  user: "Plan the TDD for the notification queue processor"
+  assistant: "I'll generate an event-driven TDD plan with contract-first approach."
+  <commentary>
+  Message-based feature. Planner ensures event contracts are defined first, then producer/consumer tests.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/tdd-planner-mvc.md
+++ b/bee/agents/tdd-planner-mvc.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-planner-mvc
-description: Use this agent to generate a TDD plan for MVC architecture. One plan per slice. Use when architecture decision is MVC.
+description: |
+  Use this agent to generate a TDD plan for MVC architecture. One plan per slice. Use when architecture decision is MVC.
 
-<example>
-Context: Architecture-advisor confirmed the codebase uses MVC
-user: "Codebase is MVC. Generate the TDD plan for this feature."
-assistant: "I'll create a layer-by-layer TDD plan for MVC: controller, service, model."
-<commentary>
-MVC architecture confirmed. This planner generates outside-in tests through MVC layers.
-</commentary>
-</example>
+  <example>
+  Context: Architecture-advisor confirmed the codebase uses MVC
+  user: "Codebase is MVC. Generate the TDD plan for this feature."
+  assistant: "I'll create a layer-by-layer TDD plan for MVC: controller, service, model."
+  <commentary>
+  MVC architecture confirmed. This planner generates outside-in tests through MVC layers.
+  </commentary>
+  </example>
 
-<example>
-Context: Standard web app with controllers, services, and models
-user: "Plan the TDD for the user profile update feature"
-assistant: "I'll generate an MVC TDD plan with thin controllers and focused services."
-<commentary>
-Standard MVC feature. Planner ensures thin controllers, business logic in services, data in models.
-</commentary>
-</example>
+  <example>
+  Context: Standard web app with controllers, services, and models
+  user: "Plan the TDD for the user profile update feature"
+  assistant: "I'll generate an MVC TDD plan with thin controllers and focused services."
+  <commentary>
+  Standard MVC feature. Planner ensures thin controllers, business logic in services, data in models.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/tdd-planner-onion.md
+++ b/bee/agents/tdd-planner-onion.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-planner-onion
-description: Use this agent to generate an outside-in TDD plan for onion/hexagonal architecture. One plan per slice. Use when architecture decision is onion or hexagonal.
+description: |
+  Use this agent to generate an outside-in TDD plan for onion/hexagonal architecture. One plan per slice. Use when architecture decision is onion or hexagonal.
 
-<example>
-Context: Architecture-advisor recommended onion architecture for a feature
-user: "Architecture is onion. Generate the TDD plan for slice 1."
-assistant: "I'll create an outside-in TDD plan starting from the outer integration test."
-<commentary>
-Architecture decision is onion/hexagonal. This planner generates a double-loop TDD plan: outer test first, then layer by layer inward.
-</commentary>
-</example>
+  <example>
+  Context: Architecture-advisor recommended onion architecture for a feature
+  user: "Architecture is onion. Generate the TDD plan for slice 1."
+  assistant: "I'll create an outside-in TDD plan starting from the outer integration test."
+  <commentary>
+  Architecture decision is onion/hexagonal. This planner generates a double-loop TDD plan: outer test first, then layer by layer inward.
+  </commentary>
+  </example>
 
-<example>
-Context: Complex domain logic with explicit port boundaries needed
-user: "Plan the TDD for the payment processing feature"
-assistant: "I'll generate an onion TDD plan with pure domain core and explicit ports."
-<commentary>
-Payment processing has complex domain logic. Onion planner ensures pure domain, explicit ports, and thin adapters.
-</commentary>
-</example>
+  <example>
+  Context: Complex domain logic with explicit port boundaries needed
+  user: "Plan the TDD for the payment processing feature"
+  assistant: "I'll generate an onion TDD plan with pure domain core and explicit ports."
+  <commentary>
+  Payment processing has complex domain logic. Onion planner ensures pure domain, explicit ports, and thin adapters.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/tdd-planner-simple.md
+++ b/bee/agents/tdd-planner-simple.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-planner-simple
-description: Use this agent to generate a simple test-first plan. For small features and utilities. Use when architecture decision is simple or default.
+description: |
+  Use this agent to generate a simple test-first plan. For small features and utilities. Use when architecture decision is simple or default.
 
-<example>
-Context: Simple utility function or small feature that doesn't need architecture layers
-user: "Plan the TDD for this helper function"
-assistant: "I'll create a simple test-first plan — test, implement, refactor."
-<commentary>
-Simple feature. No architecture layers needed. Basic red-green-refactor cycle.
-</commentary>
-</example>
+  <example>
+  Context: Simple utility function or small feature that doesn't need architecture layers
+  user: "Plan the TDD for this helper function"
+  assistant: "I'll create a simple test-first plan — test, implement, refactor."
+  <commentary>
+  Simple feature. No architecture layers needed. Basic red-green-refactor cycle.
+  </commentary>
+  </example>
 
-<example>
-Context: Architecture-advisor recommended simple pattern
-user: "Architecture is simple. Generate the TDD plan."
-assistant: "I'll create a straightforward test-first plan without layer ceremony."
-<commentary>
-Architecture decision is simple/default. This planner generates a lean test-implement-refactor plan.
-</commentary>
-</example>
+  <example>
+  Context: Architecture-advisor recommended simple pattern
+  user: "Architecture is simple. Generate the TDD plan."
+  assistant: "I'll create a straightforward test-first plan without layer ceremony."
+  <commentary>
+  Architecture decision is simple/default. This planner generates a lean test-implement-refactor plan.
+  </commentary>
+  </example>
 
 model: inherit
 color: blue

--- a/bee/agents/tdd-test-writer.md
+++ b/bee/agents/tdd-test-writer.md
@@ -1,24 +1,25 @@
 ---
 name: tdd-test-writer
-description: Use this agent as the "test" side of ping-pong TDD. It writes exactly ONE failing test, runs it to confirm RED, and returns the test name and error. Never writes more than one test per invocation.
+description: |
+  Use this agent as the "test" side of ping-pong TDD. It writes exactly ONE failing test, runs it to confirm RED, and returns the test name and error. Never writes more than one test per invocation.
 
-<example>
-Context: Ping-pong parent agent needs the next failing test for an AC
-user: "Write the Zero case test for: User can create an account with email and password"
-assistant: "I'll write a test for the simplest case — creating an account with valid email and password."
-<commentary>
-Test-writer writes one test, runs it, confirms it fails (RED), and returns the failure details.
-</commentary>
-</example>
+  <example>
+  Context: Ping-pong parent agent needs the next failing test for an AC
+  user: "Write the Zero case test for: User can create an account with email and password"
+  assistant: "I'll write a test for the simplest case — creating an account with valid email and password."
+  <commentary>
+  Test-writer writes one test, runs it, confirms it fails (RED), and returns the failure details.
+  </commentary>
+  </example>
 
-<example>
-Context: Ping-pong parent agent needs a boundary case test
-user: "Write the Boundary case test for: Password must be at least 8 characters"
-assistant: "I'll write a test for the boundary — a password with exactly 7 characters should be rejected."
-<commentary>
-Test-writer targets a specific ZOMBIE step for the AC. One test only.
-</commentary>
-</example>
+  <example>
+  Context: Ping-pong parent agent needs a boundary case test
+  user: "Write the Boundary case test for: Password must be at least 8 characters"
+  assistant: "I'll write a test for the boundary — a password with exactly 7 characters should be rejected."
+  <commentary>
+  Test-writer targets a specific ZOMBIE step for the AC. One test only.
+  </commentary>
+  </example>
 
 model: inherit
 color: red

--- a/bee/agents/tidy.md
+++ b/bee/agents/tidy.md
@@ -1,24 +1,25 @@
 ---
 name: tidy
-description: Use this agent to clean up the area before building. Creates a separate commit. Optional — skipped if area is clean. Use when context gatherer flags tidy opportunities.
+description: |
+  Use this agent to clean up the area before building. Creates a separate commit. Optional — skipped if area is clean. Use when context gatherer flags tidy opportunities.
 
-<example>
-Context: Context-gatherer flagged dead code and a long function in the change area
-user: "Add pagination to the user list endpoint"
-assistant: "The context scan found some tidy opportunities in the area. Let me clean up first."
-<commentary>
-Context-gatherer flagged tidy items. The tidy agent cleans up before the feature work begins, in a separate commit.
-</commentary>
-</example>
+  <example>
+  Context: Context-gatherer flagged dead code and a long function in the change area
+  user: "Add pagination to the user list endpoint"
+  assistant: "The context scan found some tidy opportunities in the area. Let me clean up first."
+  <commentary>
+  Context-gatherer flagged tidy items. The tidy agent cleans up before the feature work begins, in a separate commit.
+  </commentary>
+  </example>
 
-<example>
-Context: Orchestrator detected broken tests near the change area
-user: "Refactor the notification service"
-assistant: "There are broken tests in this area. Let me fix those first in a cleanup commit."
-<commentary>
-Broken tests in the change area should be fixed before new feature work. Tidy agent handles this as a separate commit.
-</commentary>
-</example>
+  <example>
+  Context: Orchestrator detected broken tests near the change area
+  user: "Refactor the notification service"
+  assistant: "There are broken tests in this area. Let me fix those first in a cleanup commit."
+  <commentary>
+  Broken tests in the change area should be fixed before new feature work. Tidy agent handles this as a separate commit.
+  </commentary>
+  </example>
 
 model: inherit
 color: green

--- a/bee/agents/verifier.md
+++ b/bee/agents/verifier.md
@@ -1,24 +1,25 @@
 ---
 name: verifier
-description: Use this agent to verify a completed slice — tests pass, criteria met, patterns followed. Risk-aware. Use after execution of each slice.
+description: |
+  Use this agent to verify a completed slice — tests pass, criteria met, patterns followed. Risk-aware. Use after execution of each slice.
 
-<example>
-Context: A TDD plan slice has been executed and needs verification
-user: "Slice 1 is done. Verify it."
-assistant: "I'll run tests, check plan completion, and validate acceptance criteria."
-<commentary>
-Post-execution verification. Verifier runs the full test suite, checks AC coverage, and reports pass/fail.
-</commentary>
-</example>
+  <example>
+  Context: A TDD plan slice has been executed and needs verification
+  user: "Slice 1 is done. Verify it."
+  assistant: "I'll run tests, check plan completion, and validate acceptance criteria."
+  <commentary>
+  Post-execution verification. Verifier runs the full test suite, checks AC coverage, and reports pass/fail.
+  </commentary>
+  </example>
 
-<example>
-Context: Bee build workflow automatically verifies after slice execution
-user: "Execute the TDD plan and verify each slice"
-assistant: "Slice 1 complete. Running verification now."
-<commentary>
-Automatic verification step in the build workflow. Catches issues while context is fresh.
-</commentary>
-</example>
+  <example>
+  Context: Bee build workflow automatically verifies after slice execution
+  user: "Execute the TDD plan and verify each slice"
+  assistant: "Slice 1 complete. Running verification now."
+  <commentary>
+  Automatic verification step in the build workflow. Catches issues while context is fresh.
+  </commentary>
+  </example>
 
 model: inherit
 color: yellow


### PR DESCRIPTION
## Why

Two issues blocking the `bee` plugin from passing `claude plugin validate` (the same check the community-marketplace review pipeline runs):

1. **Broken agent frontmatter (all 35 agents).** Each `bee/agents/*.md` placed its `<example>` blocks as bare lines *inside* the YAML frontmatter. A line starting with `<` is an "unexpected token" in YAML, so the **entire frontmatter failed to parse and every field was silently dropped at runtime** — `name`, `description`, `model`, `color`, `tools`, `skills`. In effect, every bee agent was loading with no metadata (no tool restrictions, no model override, no skills).

2. **License mislabeled.** `bee/.claude-plugin/plugin.json` said `"Proprietary"` while `bee/LICENSE` is the MIT license text.

## What changed

- Folded each agent's description text + `<example>` blocks into a `description: |` **block scalar**, so the examples stay part of the description (the intended agent format) and `model`/`color`/`tools`/`skills` parse as real fields again.
- Set `plugin.json` license to `MIT` to match the existing `LICENSE` file.

## Validation

`claude plugin validate ./bee` → ✔ passes (only the pre-existing, non-blocking *"CLAUDE.md at plugin root is not loaded as project context"* warning remains).

## Behavior note

Because the frontmatter now parses, bee's agents load their real metadata for the first time — e.g. `slice-coder` runs on `sonnet`, review agents get their `Read/Glob/Grep` tool limits, and skills attach. This is the intended behavior, but reviewers should be aware it's an effective behavior change from the previously-broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)