### PR TITLE
feat(ccaf): browser-based exam mode with exam library management

### DIFF
--- a/ccaf/.claude-plugin/plugin.json
+++ b/ccaf/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccaf",
   "version": "0.1.1",
-  "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. Assembles a 60-question case-study-framed mock with machine-enforced domain weighting — every question generated fresh per attempt and independently verified — administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown. Run /ccaf:mock-exam.",
+  "description": "CCAF (Claude Certified Architect – Foundations) mock-exam readiness gate. Assembles a 60-question case-study-framed mock with machine-enforced domain weighting — every question generated fresh per attempt and independently verified — administers it 4 per screen with resumable progress, and scores it on the real 100–1000 band with a 720 pass line plus a per-domain breakdown. Run /ccaf:mock-exam (terminal) or /ccaf:mock-exam --web (browser UI on port 8765).",
   "author": {
     "name": "Incubyte"
   },

--- a/ccaf/CLAUDE.md
+++ b/ccaf/CLAUDE.md
@@ -1,27 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # CCAF: Claude Certified Architect – Foundations mock exam
 
 A self-serve readiness gate for the CCAF certification. `/ccaf:mock-exam` administers a faithful
 mock exam and reports a scaled /1000 score with the 720 pass line, so a candidate can check
 readiness before booking the real (paid) exam.
 
+## Running tests
+
+```bash
+bash scripts/tests/ccaf-exam.test.sh   # shell state helper (init/get/record/score/clear)
+python3 scripts/tests/server.test.py   # web server (parser, HTTP routes, submit)
+```
+
+`ccaf-exam.test.sh` exercises `scripts/ccaf-exam.sh` end-to-end: data-file structure,
+init/get/record/score/clear, resume cursor, scoring math, composition enforcement, and
+concurrency guards. Isolated via `CCAF_EXAM_FILE` env var — it never touches `~/.claude/`.
+
+`server.test.py` exercises `web/server.py`: `parse_questions_file`, `parse_answers_file`,
+and all HTTP routes (ping, exams list, exam/result fetch, submit). Each test class
+spins up its own ephemeral-port server instance and cleans up after itself.
+
 ## Layout
 
 - `commands/prepare.md` — the `/ccaf:prepare` command (loads the tutor skill).
 - `commands/mock-exam.md` — the `/ccaf:mock-exam` command (loads the exam engine skill).
 - `skills/ccaf-tutor/SKILL.md` — the conversational teaching engine (topic menu → teach → check → adapt); stateless.
-- `skills/ccaf-exam/SKILL.md` — the assemble → administer → score engine.
+- `skills/ccaf-exam/SKILL.md` — the assemble → administer → score engine; contains a **Web Mode** section (triggered by `--web`) that hands off to the browser after assembly.
 - `agents/ccaf-check-author.md` — mini-agent the tutor spawns to author one scenario check at a time.
 - `data/ccaf-blueprint.md` — domains, weights, scenarios, the syllabus, scope lists, scoring. Shared curriculum for both commands.
 - `data/ccaf-question-bank.md` — 12 self-authored reference questions; style/difficulty anchors only, never served in an exam (helper-enforced).
-- `scripts/ccaf-exam.sh` — silent state helper (init / get / record / blanks / audit / score / clear); never use Write/Edit on the attempt files. `init` takes one payload (with keys) and splits it: questions file (write-once) + answers file (hot, ~60 lines) — so `record` rewrites only the tiny answers file and `get` output is key-free. Guards: `init` validates the payload — and, for 60-question exams, enforces the blueprint composition (domain quotas 16/11/12/12/9, 4 scenarios in contiguous sections each headed by its own `[[CASE:]]` brief — so a screen's brief always matches its questions — non-degenerate key spread) — and refuses to overwrite an in-progress attempt (unless `--force`); `record` takes one or more `--q/--answer` pairs atomically (one call per screen) and requires an in-progress attempt; `score` cross-validates the pair and requires `--partial` to score with unanswered questions. All writes serialize through a directory lock (stale locks are stolen), so mid-exam `record` calls run **in the background** while the next screen shows; the final screen records in the foreground and completion is verified before scoring.
+- `scripts/ccaf-exam.sh` — silent state helper (init / get / record / blanks / audit / score / clear); never use Write/Edit on the attempt files.
+- `scripts/start-web-server.sh` — web mode launcher: generates a timestamped exam ID, exports the current exam pair to `~/.claude/ccaf-exams/<ID>.json` via `web/server.py`, starts the Python server on port **8765**, opens the browser.
 - `scripts/tests/ccaf-exam.test.sh` — shell test harness for the data files + helper logic.
+- `web/server.py` — Python stdlib HTTP server (no external deps). Two modes: `export` (parse exam files → write JSON with Base64-obfuscated keys) and `serve` (API for the browser app: GET `/`, `/ping`, `/exams`, `/exam/<id>`, `/result/<id>`; POST `/submit`). Shuts itself down after receiving `POST /submit`.
+- `web/app.html` — self-contained single-file browser exam app (HTML + vanilla JS + inline CSS). Start screen (exam library), exam screen (free navigation, flagging, 120-min enforced timer), result screen (per-domain CSS bar chart).
 
 ## Conventions
 
 - Per-attempt state is a pair of user-level, gitignored files: `~/.claude/ccaf-exam.local.md`
   (questions — write-once, key-free) and `~/.claude/ccaf-exam.local.answers.md` (keys + recorded
   answers + progress — small, rewritten per screen, never read during administration).
+- **Never use Write/Edit on the attempt files.** All reads/writes go through `ccaf-exam.sh`
+  subcommands so that answer keys stay out of the conversation context and atomic rewrites are guaranteed.
+- **Web mode** (`/ccaf:mock-exam --web`): after assembly, `start-web-server.sh` exports the exam to `~/.claude/ccaf-exams/` as JSON (with Base64-obfuscated keys), starts a Python stdlib server on port **8765**, and opens the browser. The server shuts itself down after receiving the submit POST. Saved exams accumulate in `~/.claude/ccaf-exams/`; results alongside as `<id>-result.json`.
+- The exam file path is overridable: `CCAF_EXAM_FILE=/path/to/file bash scripts/ccaf-exam.sh …`
+  (the answers file path derives automatically from it). The test suite uses this.
 - Untimed, honor-system, fully offline. Self-serve: nothing is reported or persisted as history.
   The real exam's 120-minute budget is stated once up front for self-pacing; no time is ever captured.
 - Scoring: `scaled = 100 + 15 × correct` (linear over the real 100–1000 band); pass = 720 (≥ 42/60).
 - The scaled score is an honest estimate, never presented as Anthropic's proprietary equating curve.
+
+## State helper subcommands
+
+```
+ccaf-exam.sh init [--force]           # read full payload from stdin (with keys), validate, split-write both files
+ccaf-exam.sh get [--field <name>]     # print key-free questions file, or one frontmatter field
+ccaf-exam.sh record --q N --answer X  # record one or more answers atomically (one call per screen)
+ccaf-exam.sh blanks                   # list unanswered question numbers
+ccaf-exam.sh audit                    # print composition histogram (domain quotas, key spread)
+ccaf-exam.sh score [--partial]        # tally + scaled score + per-domain; marks attempt completed
+ccaf-exam.sh clear                    # remove both attempt files
+```
+
+`init` enforces the blueprint composition for 60-question exams: domain quotas 16/11/12/12/9,
+exactly 4 scenarios, contiguous `[[CASE:]]`-headed sections, non-degenerate key spread (6–26
+per letter). `record` calls mid-exam run in the background (the next screen shows immediately);
+the final screen records in the foreground. All writes serialize through a directory lock.
+
+## Blueprint composition (enforced at init and score)
+
+| Domain | Questions | Weight |
+| --- | --- | --- |
+| D1 | 16 | 27 % |
+| D2 | 11 | 18 % |
+| D3 | 12 | 20 % |
+| D4 | 12 | 20 % |
+| D5 |  9 | 15 % |
+
+4 of 6 available scenarios are selected per attempt. Each scenario's questions form a
+contiguous section in the file, headed by a `[[CASE:slug]]` block (title + brief). This
+guarantees the brief shown above a screen always belongs to that screen's questions.
+
+## Plugin structure
+
+This is a Claude Code plugin (no build step, no `package.json`). The plugin manifest is at
+`.claude-plugin/plugin.json`. Commands in `commands/` are loaded by the Claude Code harness;
+each file's YAML frontmatter (`allowed-tools`) restricts what Bash commands the command may run
+— `mock-exam.md` is sandboxed to `scripts/ccaf-exam.sh *`.

--- a/ccaf/CLAUDE.md
+++ b/ccaf/CLAUDE.md
@@ -12,7 +12,7 @@ readiness before booking the real (paid) exam.
 
 ```bash
 bash scripts/tests/ccaf-exam.test.sh   # shell state helper (init/get/record/score/clear)
-python3 scripts/tests/server.test.py   # web server (parser, HTTP routes, submit)
+python3 scripts/tests/server.test.py   # web server (parser, HTTP routes, import, submit)
 ```
 
 `ccaf-exam.test.sh` exercises `scripts/ccaf-exam.sh` end-to-end: data-file structure,
@@ -20,7 +20,7 @@ init/get/record/score/clear, resume cursor, scoring math, composition enforcemen
 concurrency guards. Isolated via `CCAF_EXAM_FILE` env var — it never touches `~/.claude/`.
 
 `server.test.py` exercises `web/server.py`: `parse_questions_file`, `parse_answers_file`,
-and all HTTP routes (ping, exams list, exam/result fetch, submit). Each test class
+and all HTTP routes (ping, exams list, exam/result fetch, import, submit). Each test class
 spins up its own ephemeral-port server instance and cleans up after itself.
 
 ## Layout
@@ -33,9 +33,9 @@ spins up its own ephemeral-port server instance and cleans up after itself.
 - `data/ccaf-blueprint.md` — domains, weights, scenarios, the syllabus, scope lists, scoring. Shared curriculum for both commands.
 - `data/ccaf-question-bank.md` — 12 self-authored reference questions; style/difficulty anchors only, never served in an exam (helper-enforced).
 - `scripts/ccaf-exam.sh` — silent state helper (init / get / record / blanks / audit / score / clear); never use Write/Edit on the attempt files.
-- `scripts/start-web-server.sh` — web mode launcher: generates a timestamped exam ID, exports the current exam pair to `~/.claude/ccaf-exams/<ID>.json` via `web/server.py`, starts the Python server on port **8765**, opens the browser.
+- `scripts/start-web-server.sh` — web mode launcher: generates a timestamped exam ID, exports the current exam pair to `~/Documents/CCAF Exams/<ID>.json` via `web/server.py`, starts or reuses the Python server on port **8765**, opens the browser.
 - `scripts/tests/ccaf-exam.test.sh` — shell test harness for the data files + helper logic.
-- `web/server.py` — Python stdlib HTTP server (no external deps). Two modes: `export` (parse exam files → write JSON with Base64-obfuscated keys) and `serve` (API for the browser app: GET `/`, `/ping`, `/exams`, `/exam/<id>`, `/result/<id>`; POST `/submit`). Shuts itself down after receiving `POST /submit`.
+- `web/server.py` — Python stdlib HTTP server (no external deps). Two modes: `export` (parse exam files → write JSON with Base64-obfuscated keys) and `serve` (API for the browser app: GET `/`, `/ping`, `/exams`, `/exam/<id>`, `/result/<id>`, `/reveal`; POST `/submit`, `/import`). Shuts itself down after receiving `POST /submit`. `/reveal` opens the exam folder in Finder/file manager.
 - `web/app.html` — self-contained single-file browser exam app (HTML + vanilla JS + inline CSS). Start screen (exam library), exam screen (free navigation, flagging, 120-min enforced timer), result screen (per-domain CSS bar chart).
 
 ## Conventions
@@ -45,7 +45,7 @@ spins up its own ephemeral-port server instance and cleans up after itself.
   answers + progress — small, rewritten per screen, never read during administration).
 - **Never use Write/Edit on the attempt files.** All reads/writes go through `ccaf-exam.sh`
   subcommands so that answer keys stay out of the conversation context and atomic rewrites are guaranteed.
-- **Web mode** (`/ccaf:mock-exam --web`): after assembly, `start-web-server.sh` exports the exam to `~/.claude/ccaf-exams/` as JSON (with Base64-obfuscated keys), starts a Python stdlib server on port **8765**, and opens the browser. The server shuts itself down after receiving the submit POST. Saved exams accumulate in `~/.claude/ccaf-exams/`; results alongside as `<id>-result.json`.
+- **Web mode** (`/ccaf:mock-exam --web`): after assembly, `start-web-server.sh` exports the exam to `~/Documents/CCAF Exams/` as JSON (with Base64-obfuscated keys), starts a Python stdlib server on port **8765**, and opens the browser. The server shuts itself down after receiving the submit POST. Saved exams accumulate in `~/Documents/CCAF Exams/`; results alongside as `<id>-result.json`. Server reuse: if port 8765 is already responding to `/ping`, the script skips starting a new process. The "Open exams folder" link on the start screen calls `GET /reveal` to open the folder in Finder (macOS) or file manager (Linux).
 - The exam file path is overridable: `CCAF_EXAM_FILE=/path/to/file bash scripts/ccaf-exam.sh …`
   (the answers file path derives automatically from it). The test suite uses this.
 - Untimed, honor-system, fully offline. Self-serve: nothing is reported or persisted as history.

--- a/ccaf/README.md
+++ b/ccaf/README.md
@@ -101,6 +101,12 @@ Answer the questions four to a screen. When you finish, you get your scaled scor
 
 Discard any in-progress or completed attempt and assemble a brand-new exam.
 
+```bash
+/ccaf:mock-exam --web
+```
+
+Assemble a new exam (or resume an in-progress one) and open it in a self-contained browser UI on port **8765**. The browser app handles navigation, flagging, and submission; your scaled score and per-domain breakdown are shown there. Combines with `fresh`: `fresh --web` discards any existing attempt before assembling. Exams accumulate in `~/Documents/CCAF Exams/` as JSON; the server shuts down after submit.
+
 **Resume:** the attempt persists to `~/.claude/ccaf-exam.local.md`. Close your terminal mid-exam and re-run `/ccaf:mock-exam` — it greets you with "Welcome back" and continues from the next unanswered question.
 
 **Honor system:** untimed, self-serve, nothing reported or shared. The answer key lives in a separate local answers file (`~/.claude/ccaf-exam.local.answers.md`) that is never shown — and never even read — during the exam; it exists so resume and scoring work. Peeking at it only cheats you before a paid exam.
@@ -133,8 +139,12 @@ ccaf/
 │   └── ccaf-question-bank.md      # 12 self-authored reference questions (anchors only — never served)
 ├── scripts/
 │   ├── ccaf-exam.sh               # silent state helper (init / get / record / score / clear)
+│   ├── start-web-server.sh        # web mode launcher: exports exam JSON, starts server, opens browser
 │   └── tests/
 │       └── ccaf-exam.test.sh      # shell test harness for the data files + helper logic
+├── web/
+│   ├── server.py                  # Python stdlib HTTP server (export + serve modes; no external deps)
+│   └── app.html                   # self-contained browser exam app (start screen, exam, result)
 ├── CLAUDE.md                      # plugin conventions
 ├── README.md
 └── LICENSE

--- a/ccaf/commands/mock-exam.md
+++ b/ccaf/commands/mock-exam.md
@@ -1,7 +1,7 @@
 ---
 description: Take a CCAF (Claude Certified Architect – Foundations) mock exam — 60 weighted questions, a scaled /1000 score, and a 720 readiness verdict. Resumable.
-argument-hint: "(no args) — start or resume; 'fresh' — discard any attempt and start new"
-allowed-tools: ["Read", "AskUserQuestion", "Skill", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/ccaf-exam.sh *)"]
+argument-hint: "(no args) — start or resume; 'fresh' — start new; '--web' — open a browser-based exam UI"
+allowed-tools: ["Read", "AskUserQuestion", "Skill", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/ccaf-exam.sh *)", "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/start-web-server.sh *)"]
 ---
 
 ## Skill Loading
@@ -25,6 +25,7 @@ pass line. The scaled number is an honest estimate — not Anthropic's proprieta
 
 - empty — start a new attempt, or offer to resume an in-progress one.
 - `fresh` — discard any existing attempt and assemble a new exam.
+- `--web` — assemble a new exam then hand it off to the browser-based UI (port 8765). Combines with `fresh`: `fresh --web` discards any existing attempt before assembling.
 
 ## Flow (delegated to the ccaf-exam skill)
 

--- a/ccaf/scripts/ccaf-exam.sh
+++ b/ccaf/scripts/ccaf-exam.sh
@@ -68,6 +68,7 @@ set -eo pipefail
 
 EXAM_FILE="${CCAF_EXAM_FILE:-$HOME/.claude/ccaf-exam.local.md}"
 ANSWERS_FILE="${EXAM_FILE%.md}.answers.md"
+WEB_ID_FILE="${EXAM_FILE%.md}.web-id"
 LOCK_DIR="$EXAM_FILE.lock"
 
 die() { echo "ccaf-exam: $*" >&2; exit 1; }
@@ -172,9 +173,10 @@ check_composition_questions() {
   # Case-study structure: each [[CASE:slug]] appears exactly once and directly
   # heads a contiguous run of its own questions — so the brief shown above a
   # screen always belongs to that screen's questions, never a previous case.
+  # Slug grammar [a-z0-9-]+ — keep in sync with web/server.py parse_questions_file.
   local struct
   struct="$(awk '
-    /^\[\[CASE:[a-z-]+\]\]$/ {
+    /^\[\[CASE:[a-z0-9-]+\]\]$/ {
       c = $0; sub(/^\[\[CASE:/, "", c); sub(/\]\]$/, "", c)
       if (seen[c]++) { print "case block " c " appears more than once (sections must be contiguous)"; exit }
       cur = c; next
@@ -411,7 +413,7 @@ cmd_score() {
 
 cmd_clear() {
   acquire_lock
-  rm -f "$EXAM_FILE" "$ANSWERS_FILE"
+  rm -f "$EXAM_FILE" "$ANSWERS_FILE" "$WEB_ID_FILE"
   echo "Exam cleared."
 }
 

--- a/ccaf/scripts/start-web-server.sh
+++ b/ccaf/scripts/start-web-server.sh
@@ -7,7 +7,7 @@
 # Steps:
 #   1. Generate a timestamped exam ID.
 #   2. Export the current exam pair (~/.claude/ccaf-exam.local.{md,answers.md})
-#      to ~/.claude/ccaf-exams/<EXAM_ID>.json via server.py (export mode).
+#      to ~/Documents/CCAF Exams/<EXAM_ID>.json via server.py (export mode).
 #   3. Check if the server is already running on PORT.  If not, start it.
 #   4. Open the browser at http://localhost:PORT/?exam=<EXAM_ID>.
 #   5. Print the URL so the skill can relay it to the user.
@@ -29,19 +29,52 @@ done
 
 SERVER_PY="$PLUGIN_ROOT/web/server.py"
 EXAM_SRC="$HOME/.claude/ccaf-exam.local"
-EXAM_DIR="$HOME/.claude/ccaf-exams"
+EXAM_DIR="$HOME/Documents/CCAF Exams"
+WEB_ID_FILE="${EXAM_SRC}.web-id"
 PID_FILE="$HOME/.claude/ccaf-web-server.pid"
 
 [[ -f "$SERVER_PY" ]] || { echo "start-web-server: server.py not found at $SERVER_PY" >&2; exit 1; }
 [[ -f "${EXAM_SRC}.md" ]] || { echo "start-web-server: no exam file at ${EXAM_SRC}.md" >&2; exit 1; }
 
-# ── 1. Export the current exam to JSON ───────────────────────────────────────
+# ── 1. Reuse existing export or create a new one ─────────────────────────────
 mkdir -p "$EXAM_DIR"
-EXAM_ID="ccaf-$(date +%Y%m%d-%H%M%S)"
-python3 "$SERVER_PY" export \
-  --exam-id    "$EXAM_ID" \
-  --exam-src   "$EXAM_SRC" \
-  --exam-dir   "$EXAM_DIR"
+
+# ── Backward compat: migrate exams from the legacy hidden location ────────────
+# Earlier versions stored exams in ~/.claude/ccaf-exams. Move any that predate
+# the relocation into ~/Documents/CCAF Exams so upgrading users keep their library.
+LEGACY_EXAM_DIR="$HOME/.claude/ccaf-exams"
+if [[ -d "$LEGACY_EXAM_DIR" ]]; then
+  migrated=0
+  for f in "$LEGACY_EXAM_DIR"/*.json; do
+    [[ -e "$f" ]] || continue            # glob matched nothing
+    dest="$EXAM_DIR/$(basename "$f")"
+    [[ -e "$dest" ]] && continue         # never clobber a copy already in the new location
+    mv "$f" "$dest" && migrated=$((migrated + 1))
+  done
+  rmdir "$LEGACY_EXAM_DIR" 2>/dev/null || true   # remove only if now empty
+  if (( migrated > 0 )); then
+    echo "Migrated ${migrated} exam file(s) from ${LEGACY_EXAM_DIR} to ${EXAM_DIR}."
+  fi
+fi
+
+EXAM_ID=""
+if [[ -f "$WEB_ID_FILE" ]]; then
+  CANDIDATE=$(cat "$WEB_ID_FILE" 2>/dev/null || true)
+  if [[ -n "$CANDIDATE" && -f "$EXAM_DIR/$CANDIDATE.json" ]]; then
+    EXAM_ID="$CANDIDATE"
+    echo "Reusing existing exam export ${EXAM_ID}."
+  fi
+fi
+
+if [[ -z "$EXAM_ID" ]]; then
+  EXAM_ID="ccaf-$(date +%Y%m%d-%H%M%S)"
+  python3 "$SERVER_PY" export \
+    --exam-id    "$EXAM_ID" \
+    --exam-src   "$EXAM_SRC" \
+    --exam-dir   "$EXAM_DIR" \
+    --name       "${USER:-$(whoami)} - $(date +'%b %d, %Y')"
+  echo "$EXAM_ID" > "$WEB_ID_FILE"
+fi
 
 # ── 3. Start server if not running ───────────────────────────────────────────
 server_alive() {

--- a/ccaf/scripts/start-web-server.sh
+++ b/ccaf/scripts/start-web-server.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# start-web-server.sh — Start (or reuse) the CCAF exam web server.
+#
+# Usage:
+#   start-web-server.sh --port PORT --plugin-root PATH
+#
+# Steps:
+#   1. Generate a timestamped exam ID.
+#   2. Export the current exam pair (~/.claude/ccaf-exam.local.{md,answers.md})
+#      to ~/.claude/ccaf-exams/<EXAM_ID>.json via server.py (export mode).
+#   3. Check if the server is already running on PORT.  If not, start it.
+#   4. Open the browser at http://localhost:PORT/?exam=<EXAM_ID>.
+#   5. Print the URL so the skill can relay it to the user.
+set -eo pipefail
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+PORT=8765
+PLUGIN_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)        PORT="$2";        shift 2 ;;
+    --plugin-root) PLUGIN_ROOT="$2"; shift 2 ;;
+    *) echo "start-web-server: unknown flag $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$PLUGIN_ROOT" ]] || { echo "start-web-server: --plugin-root is required" >&2; exit 1; }
+
+SERVER_PY="$PLUGIN_ROOT/web/server.py"
+EXAM_SRC="$HOME/.claude/ccaf-exam.local"
+EXAM_DIR="$HOME/.claude/ccaf-exams"
+PID_FILE="$HOME/.claude/ccaf-web-server.pid"
+
+[[ -f "$SERVER_PY" ]] || { echo "start-web-server: server.py not found at $SERVER_PY" >&2; exit 1; }
+[[ -f "${EXAM_SRC}.md" ]] || { echo "start-web-server: no exam file at ${EXAM_SRC}.md" >&2; exit 1; }
+
+# ── 1. Export the current exam to JSON ───────────────────────────────────────
+mkdir -p "$EXAM_DIR"
+EXAM_ID="ccaf-$(date +%Y%m%d-%H%M%S)"
+python3 "$SERVER_PY" export \
+  --exam-id    "$EXAM_ID" \
+  --exam-src   "$EXAM_SRC" \
+  --exam-dir   "$EXAM_DIR"
+
+# ── 3. Start server if not running ───────────────────────────────────────────
+server_alive() {
+  curl -s --max-time 1 "http://localhost:${PORT}/ping" 2>/dev/null | grep -q "pong"
+}
+
+if server_alive; then
+  echo "Reusing existing server on port ${PORT}."
+else
+  # Clean up stale PID file
+  if [[ -f "$PID_FILE" ]]; then
+    OLD_PID=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [[ -n "$OLD_PID" ]] && kill -0 "$OLD_PID" 2>/dev/null; then
+      kill "$OLD_PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+  fi
+
+  SERVER_LOG="$HOME/.claude/ccaf-server.log"
+  python3 "$SERVER_PY" serve \
+    --port        "$PORT" \
+    --exam-dir    "$EXAM_DIR" \
+    --plugin-root "$PLUGIN_ROOT" \
+    >> "$SERVER_LOG" 2>&1 &
+  echo $! > "$PID_FILE"
+
+  # Wait until server responds (up to 8 seconds)
+  MAX=40
+  for ((i=0; i<MAX; i++)); do
+    sleep 0.2
+    if server_alive; then break; fi
+    if (( i == MAX - 1 )); then
+      echo "start-web-server: server did not start in time" >&2
+      [[ -s "$SERVER_LOG" ]] && echo "--- server log ---" >&2 && cat "$SERVER_LOG" >&2
+      exit 1
+    fi
+  done
+  echo "Server started (PID $(cat "$PID_FILE"))."
+fi
+
+# ── 4. Open browser ───────────────────────────────────────────────────────────
+URL="http://localhost:${PORT}/?exam=${EXAM_ID}"
+if command -v open &>/dev/null; then
+  open "$URL"
+elif command -v xdg-open &>/dev/null; then
+  xdg-open "$URL"
+else
+  echo "Could not detect a browser opener (tried open, xdg-open)." >&2
+fi
+
+# ── 5. Output URL for the skill to relay ─────────────────────────────────────
+echo "Exam open at: ${URL}"

--- a/ccaf/scripts/tests/server.test.py
+++ b/ccaf/scripts/tests/server.test.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Tests for web/server.py — parser functions and HTTP routes.
+Run: python3 scripts/tests/server.test.py
+"""
+
+import http.client
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import HTTPServer
+
+REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+)
+sys.path.insert(0, os.path.join(REPO_ROOT, 'web'))
+import server as srv  # noqa: E402  (must come after sys.path tweak)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+QUESTIONS_FIXTURE = """\
+---
+status: in_progress
+total: 4
+scenarios: s1,s2
+next_index: 1
+---
+[[CASE:s1]]
+title: Scenario One
+brief: Brief for scenario one.
+[[Q1]]
+domain: D1
+scenario: s1
+source: generated
+id: gen-01
+stem: What is the answer to Q1?
+A) Apple
+B) Banana
+C) Cherry
+D) Date
+answer_key: B
+user_answer:
+[[Q2]]
+domain: D2
+scenario: s1
+source: generated
+id: gen-02
+stem: What is the answer to Q2?
+A) Alpha
+B) Beta
+C) Gamma
+D) Delta
+answer_key: A
+user_answer:
+[[CASE:s2]]
+title: Scenario Two
+brief: Brief for scenario two.
+[[Q3]]
+domain: D3
+scenario: s2
+source: generated
+id: gen-03
+stem: What is the answer to Q3?
+A) One
+B) Two
+C) Three
+D) Four
+answer_key: C
+user_answer:
+[[Q4]]
+domain: D4
+scenario: s2
+source: generated
+id: gen-04
+stem: What is the answer to Q4?
+A) Red
+B) Blue
+C) Green
+D) Yellow
+answer_key: D
+user_answer:
+"""
+
+ANSWERS_FIXTURE = """\
+---
+status: in_progress
+total: 4
+---
+1 D1 B -
+2 D2 A -
+3 D3 C -
+4 D4 D -
+"""
+
+
+# ── Server helpers ────────────────────────────────────────────────────────────
+
+def start_server(exam_dir):
+    """Start an ExamHandler server on an OS-assigned ephemeral port."""
+    s = HTTPServer(('127.0.0.1', 0), srv.ExamHandler)
+    s.exam_dir = exam_dir
+    s.plugin_root = REPO_ROOT
+    port = s.server_address[1]
+    threading.Thread(target=s.serve_forever, daemon=True).start()
+    for _ in range(40):
+        try:
+            c = http.client.HTTPConnection('127.0.0.1', port, timeout=1)
+            c.request('GET', '/ping')
+            resp = c.getresponse()
+            c.close()
+            if resp.status == 200:
+                return s, port
+        except Exception:
+            pass
+        time.sleep(0.1)
+    raise RuntimeError('Test server did not start in time')
+
+
+def http_request(method, path, body=None, port=None):
+    c = http.client.HTTPConnection('127.0.0.1', port, timeout=5)
+    headers = {}
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers = {
+            'Content-Type': 'application/json',
+            'Content-Length': str(len(data)),
+        }
+    c.request(method, path, body=data, headers=headers)
+    resp = c.getresponse()
+    status = resp.status
+    content_type = resp.getheader('Content-Type', '')
+    body_bytes = resp.read()
+    c.close()
+    return status, content_type, body_bytes
+
+
+# ── Parser tests ──────────────────────────────────────────────────────────────
+
+class TestParseQuestionsFile(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix='.md')
+        os.write(fd, QUESTIONS_FIXTURE.encode())
+        os.close(fd)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_total_and_scenarios(self):
+        total, scenarios, _, _ = srv.parse_questions_file(self.path)
+        self.assertEqual(total, 4)
+        self.assertEqual(scenarios, ['s1', 's2'])
+
+    def test_question_count(self):
+        _, _, _, questions = srv.parse_questions_file(self.path)
+        self.assertEqual(len(questions), 4)
+
+    def test_question_fields(self):
+        _, _, _, questions = srv.parse_questions_file(self.path)
+        q = questions[0]
+        self.assertEqual(q['n'], 1)
+        self.assertEqual(q['domain'], 'D1')
+        self.assertEqual(q['scenario'], 's1')
+        self.assertEqual(q['stem'], 'What is the answer to Q1?')
+        self.assertEqual(q['options']['A'], 'Apple')
+        self.assertEqual(q['options']['B'], 'Banana')
+
+    def test_case_metadata(self):
+        _, _, cases, _ = srv.parse_questions_file(self.path)
+        self.assertEqual(cases['s1']['title'], 'Scenario One')
+        self.assertEqual(cases['s1']['brief'], 'Brief for scenario one.')
+        self.assertEqual(cases['s2']['title'], 'Scenario Two')
+
+    def test_scenario_assignment(self):
+        _, _, _, questions = srv.parse_questions_file(self.path)
+        self.assertEqual(questions[0]['scenario'], 's1')
+        self.assertEqual(questions[2]['scenario'], 's2')
+
+
+class TestParseAnswersFile(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix='.md')
+        os.write(fd, ANSWERS_FIXTURE.encode())
+        os.close(fd)
+
+    def tearDown(self):
+        os.unlink(self.path)
+
+    def test_keys_parsed(self):
+        keys = srv.parse_answers_file(self.path)
+        self.assertEqual(keys, {1: 'B', 2: 'A', 3: 'C', 4: 'D'})
+
+    def test_only_valid_key_letters(self):
+        keys = srv.parse_answers_file(self.path)
+        for k, v in keys.items():
+            self.assertIsInstance(k, int)
+            self.assertIn(v, 'ABCD')
+
+
+# ── HTTP route tests ──────────────────────────────────────────────────────────
+
+class TestHTTPRoutes(unittest.TestCase):
+    """Shared server instance for all non-submit route tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.exam_dir = tempfile.mkdtemp()
+        cls.server, cls.port = start_server(cls.exam_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.server.shutdown()
+            cls.server.server_close()
+        except Exception:
+            pass
+
+    def req(self, method, path, body=None):
+        return http_request(method, path, body, port=self.__class__.port)
+
+    def test_ping(self):
+        status, _, body = self.req('GET', '/ping')
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b'pong')
+
+    def test_root_serves_html(self):
+        status, ct, _ = self.req('GET', '/')
+        self.assertEqual(status, 200)
+        self.assertIn('text/html', ct)
+
+    def test_exams_returns_list(self):
+        status, _, body = self.req('GET', '/exams')
+        self.assertEqual(status, 200)
+        self.assertIsInstance(json.loads(body), list)
+
+    def test_exam_not_found(self):
+        status, _, _ = self.req('GET', '/exam/no-such-exam')
+        self.assertEqual(status, 404)
+
+    def test_result_not_found(self):
+        status, _, _ = self.req('GET', '/result/no-such-exam')
+        self.assertEqual(status, 404)
+
+    def test_invalid_exam_id_rejected(self):
+        status, _, _ = self.req('GET', '/exam/bad..id')
+        self.assertEqual(status, 400)
+
+    def test_invalid_result_id_rejected(self):
+        status, _, _ = self.req('GET', '/result/bad..id')
+        self.assertEqual(status, 400)
+
+    def test_unknown_route_404(self):
+        status, _, _ = self.req('GET', '/no-such-route')
+        self.assertEqual(status, 404)
+
+
+class TestSubmit(unittest.TestCase):
+    """Each test gets its own server instance — POST /submit triggers shutdown."""
+
+    def setUp(self):
+        self.exam_dir = tempfile.mkdtemp()
+        self.server, self.port = start_server(self.exam_dir)
+
+    def tearDown(self):
+        try:
+            self.server.shutdown()
+            self.server.server_close()
+        except Exception:
+            pass
+
+    def req(self, method, path, body=None):
+        return http_request(method, path, body, port=self.port)
+
+    def test_submit_writes_result_file(self):
+        exam_id = 'ccaf-submit-test'
+        with open(os.path.join(self.exam_dir, f'{exam_id}.json'), 'w') as fh:
+            json.dump({'id': exam_id, 'sections': [], 'total': 1}, fh)
+
+        result = {
+            'exam_id': exam_id,
+            'correct': 1,
+            'total': 1,
+            'scaled': 115,
+            'verdict': 'FAIL',
+            'per_domain': {},
+            'answers': {'1': 'A'},
+        }
+        status, _, body = self.req('POST', '/submit', result)
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body).get('ok'))
+
+        result_path = os.path.join(self.exam_dir, f'{exam_id}-result.json')
+        self.assertTrue(os.path.exists(result_path))
+
+    def test_submit_invalid_exam_id_rejected(self):
+        status, _, _ = self.req('POST', '/submit', {'exam_id': '../bad', 'correct': 0, 'total': 1})
+        self.assertEqual(status, 400)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/ccaf/scripts/tests/server.test.py
+++ b/ccaf/scripts/tests/server.test.py
@@ -375,6 +375,11 @@ class TestHTTPRoutes(unittest.TestCase):
         status, _, _ = self.req('DELETE', '/exam/ccaf-no-such-exam')
         self.assertEqual(status, 404)
 
+    def test_heartbeat_resets_timer(self):
+        status, _, body = self.req('GET', '/heartbeat')
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b'ok')
+
     def test_reveal_returns_json(self):
         status, ct, _ = self.req('GET', '/reveal')
         self.assertNotEqual(status, 404)
@@ -432,9 +437,37 @@ class TestSubmit(unittest.TestCase):
         result_path = os.path.join(self.exam_dir, f'{exam_id}-result.json')
         self.assertTrue(os.path.exists(result_path))
 
+    def test_submit_triggers_server_shutdown(self):
+        exam_id = 'ccaf-submit-shutdown-test'
+        with open(os.path.join(self.exam_dir, f'{exam_id}.json'), 'w') as fh:
+            json.dump({'id': exam_id, 'sections': [], 'total': 1}, fh)
+        result = {
+            'exam_id': exam_id,
+            'correct': 0,
+            'total': 1,
+            'scaled': 100,
+            'verdict': 'FAIL',
+            'per_domain': {},
+            'answers': {},
+        }
+        status, _, _ = self.req('POST', '/submit', result)
+        self.assertEqual(status, 200)
+        time.sleep(0.5)
+        with self.assertRaises(Exception):
+            self.req('GET', '/ping')
+
     def test_submit_invalid_exam_id_rejected(self):
         status, _, _ = self.req('POST', '/submit', {'exam_id': '../bad', 'correct': 0, 'total': 1})
         self.assertEqual(status, 400)
+
+    def test_shutdown_beacon_stops_server(self):
+        status, _, body = self.req('POST', '/shutdown')
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body).get('ok'))
+        # Server should stop accepting connections within ~1 second
+        time.sleep(0.5)
+        with self.assertRaises(Exception):
+            self.req('GET', '/ping')
 
 
 if __name__ == '__main__':

--- a/ccaf/scripts/tests/server.test.py
+++ b/ccaf/scripts/tests/server.test.py
@@ -257,6 +257,142 @@ class TestHTTPRoutes(unittest.TestCase):
         status, _, _ = self.req('GET', '/no-such-route')
         self.assertEqual(status, 404)
 
+    def test_import_saves_and_retrieves_exam(self):
+        exam = {
+            'id': 'ccaf-import-test',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': ['s1'],
+            'total': 1,
+            'sections': [{'scenario': 's1', 'title': 'T', 'brief': 'B', 'questions': []}],
+        }
+        status, _, body = self.req('POST', '/import', exam)
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body).get('ok'))
+
+        status2, _, body2 = self.req('GET', '/exam/ccaf-import-test')
+        self.assertEqual(status2, 200)
+        self.assertEqual(json.loads(body2)['id'], 'ccaf-import-test')
+
+    def test_import_duplicate_is_409(self):
+        exam = {
+            'id': 'ccaf-dup-test',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': [],
+            'total': 1,
+            'sections': [{'scenario': 's1', 'title': 'T', 'brief': 'B', 'questions': []}],
+        }
+        self.req('POST', '/import', exam)          # first
+        status, _, _ = self.req('POST', '/import', exam)  # duplicate
+        self.assertEqual(status, 409)
+
+    def test_import_invalid_id_rejected(self):
+        status, _, _ = self.req('POST', '/import', {'id': '../etc/bad', 'sections': [], 'total': 1})
+        self.assertEqual(status, 400)
+
+    def test_import_missing_fields_rejected(self):
+        status, _, _ = self.req('POST', '/import', {'id': 'valid-id'})
+        self.assertEqual(status, 400)
+
+    def test_import_question_missing_key_rejected(self):
+        exam = {
+            'id': 'ccaf-nokey-test',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': ['s1'],
+            'total': 1,
+            'sections': [{
+                'scenario': 's1', 'title': 'T', 'brief': 'B',
+                'questions': [{
+                    'n': 1, 'domain': 'D1', 'stem': 'Q?',
+                    'options': {'A': 'a', 'B': 'b', 'C': 'c', 'D': 'd'},
+                    # no 'key' — would silently mis-score every answer
+                }],
+            }],
+        }
+        status, _, body = self.req('POST', '/import', exam)
+        self.assertEqual(status, 400)
+        self.assertIn('key', json.loads(body)['error'])
+        # and nothing was written
+        status2, _, _ = self.req('GET', '/exam/ccaf-nokey-test')
+        self.assertEqual(status2, 404)
+
+    def test_import_well_formed_question_accepted(self):
+        exam = {
+            'id': 'ccaf-goodq-test',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': ['s1'],
+            'total': 1,
+            'sections': [{
+                'scenario': 's1', 'title': 'T', 'brief': 'B',
+                'questions': [{
+                    'n': 1, 'domain': 'D1', 'stem': 'Q?',
+                    'options': {'A': 'a', 'B': 'b', 'C': 'c', 'D': 'd'},
+                    'key': 'Qg==',
+                }],
+            }],
+        }
+        status, _, body = self.req('POST', '/import', exam)
+        self.assertEqual(status, 200)
+        self.assertTrue(json.loads(body).get('ok'))
+
+    def test_rename_exam(self):
+        exam = {
+            'id': 'ccaf-rename-test',
+            'name': 'Original Name',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': [],
+            'total': 1,
+            'sections': [{'scenario': 's1', 'title': 'T', 'brief': 'B', 'questions': []}],
+        }
+        self.req('POST', '/import', exam)
+        status, _, _ = self.req('PATCH', '/exam/ccaf-rename-test', {'name': 'New Name'})
+        self.assertEqual(status, 200)
+        _, _, body = self.req('GET', '/exam/ccaf-rename-test')
+        self.assertEqual(json.loads(body)['name'], 'New Name')
+
+    def test_rename_nonexistent_is_404(self):
+        status, _, _ = self.req('PATCH', '/exam/ccaf-ghost-id', {'name': 'Valid Name'})
+        self.assertEqual(status, 404)
+
+    def test_rename_empty_name_rejected(self):
+        status, _, _ = self.req('PATCH', '/exam/ccaf-any-id', {'name': '   '})
+        self.assertEqual(status, 400)
+
+    def test_delete_exam(self):
+        exam = {
+            'id': 'ccaf-to-delete',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': [],
+            'total': 1,
+            'sections': [{'scenario': 's1', 'title': 'T', 'brief': 'B', 'questions': []}],
+        }
+        self.req('POST', '/import', exam)
+        status, _, _ = self.req('DELETE', '/exam/ccaf-to-delete')
+        self.assertEqual(status, 200)
+        status2, _, _ = self.req('GET', '/exam/ccaf-to-delete')
+        self.assertEqual(status2, 404)
+
+    def test_delete_nonexistent_is_404(self):
+        status, _, _ = self.req('DELETE', '/exam/ccaf-no-such-exam')
+        self.assertEqual(status, 404)
+
+    def test_reveal_returns_json(self):
+        status, ct, _ = self.req('GET', '/reveal')
+        self.assertNotEqual(status, 404)
+        self.assertIn('application/json', ct)
+
+    def test_import_appears_in_exams_list(self):
+        exam = {
+            'id': 'ccaf-list-check',
+            'generated_at': '2026-06-19T00:00:00',
+            'scenarios': [],
+            'total': 1,
+            'sections': [{'scenario': 's1', 'title': 'T', 'brief': 'B', 'questions': []}],
+        }
+        self.req('POST', '/import', exam)
+        status, _, body = self.req('GET', '/exams')
+        ids = [e['id'] for e in json.loads(body)]
+        self.assertIn('ccaf-list-check', ids)
+
 
 class TestSubmit(unittest.TestCase):
     """Each test gets its own server instance — POST /submit triggers shutdown."""

--- a/ccaf/skills/ccaf-exam/SKILL.md
+++ b/ccaf/skills/ccaf-exam/SKILL.md
@@ -120,6 +120,49 @@ biased key spread, or a mid-attempt overwrite — on refusal, fix the body and r
 back to Write/Edit. Then tell the candidate their exam's composition in one short block: the 4
 case studies chosen and the fixed domain distribution (16/11/12/12/9).
 
+## Web Mode
+
+If `$ARGUMENTS` contains `--web`, **do not run the terminal Administer or Score sections** —
+the browser handles administration and scoring. Follow this startup logic instead of the one
+in "On startup" above:
+
+### Web startup
+
+1. **`fresh --web`** (arguments contain both `fresh` and `--web`):
+   Run `ccaf-exam.sh clear`, go to **Assemble**, then launch below.
+
+2. **Existing attempt** (`ccaf-exam.sh get --field status` succeeds):
+   - `in_progress` — tell the user their in-progress exam is opening in the browser
+     (remaining questions are shown there). Skip Assemble; go straight to **Launch**.
+   - `completed` — tell the user their previous attempt is completed and ask via
+     **AskUserQuestion**: *Open it in the browser to review* / *Start a fresh attempt* /
+     *Cancel*. "Open to review" goes to **Launch**; "Start fresh" clears and goes to Assemble.
+   - **Malformed / unrecognised status** — explain briefly, offer *Start fresh* / *Cancel*
+     via AskUserQuestion. "Start fresh" clears and goes to Assemble.
+
+3. **No attempt** (`get` fails with "no active exam") — go to **Assemble**, then **Launch**.
+
+### Launch
+
+Run the web server launcher (foreground, so you can read its output):
+```
+${CLAUDE_PLUGIN_ROOT}/scripts/start-web-server.sh \
+  --port 8765 \
+  --plugin-root ${CLAUDE_PLUGIN_ROOT}
+```
+The script exports the current exam pair to `~/Documents/CCAF Exams/<EXAM_ID>.json` with
+Base64-obfuscated keys, starts or reuses the server on port 8765, opens the browser, and
+prints `Exam open at: http://localhost:8765/?exam=<EXAM_ID>` as its last line.
+
+Read that URL from the output and tell the user:
+> "Your exam is open in the browser at `http://localhost:8765/?exam=<EXAM_ID>`.
+> Take it there — your scaled score and per-domain breakdown will be shown in the browser
+> when you submit. The server shuts itself down after you submit."
+
+Done. Do not run Administer or Score.
+
+---
+
 ## Administer
 
 Before the first screen of a new attempt, state once: *"Heads-up: the real CCAF allows

--- a/ccaf/web/app.html
+++ b/ccaf/web/app.html
@@ -1,0 +1,1131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CCAF Mock Exam</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #f0f2f5;
+  --surface:   #ffffff;
+  --border:    #d1d5db;
+  --text:      #1f2937;
+  --muted:     #6b7280;
+  --primary:   #2563eb;
+  --primary-h: #1d4ed8;
+  --pass:      #16a34a;
+  --fail:      #dc2626;
+  --warn:      #d97706;
+  --sq-none:   #e5e7eb;
+  --sq-ans:    #2563eb;
+  --sq-flag:   #d97706;
+  --radius:    8px;
+  --shadow:    0 1px 3px rgba(0,0,0,.1), 0 1px 2px rgba(0,0,0,.06);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+/* ── Shared layout ── */
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+button {
+  cursor: pointer;
+  font: inherit;
+  border: none;
+  border-radius: var(--radius);
+  transition: background .15s, opacity .15s;
+}
+button:disabled { opacity: .45; cursor: default; }
+
+.btn-primary {
+  background: var(--primary);
+  color: #fff;
+  padding: .55rem 1.25rem;
+  font-weight: 600;
+}
+.btn-primary:hover:not(:disabled) { background: var(--primary-h); }
+
+.btn-ghost {
+  background: transparent;
+  color: var(--primary);
+  padding: .5rem 1rem;
+  border: 1.5px solid var(--primary);
+  font-weight: 500;
+}
+.btn-ghost:hover:not(:disabled) { background: #eff6ff; }
+
+.btn-danger {
+  background: var(--fail);
+  color: #fff;
+  padding: .55rem 1.25rem;
+  font-weight: 600;
+}
+.btn-danger:hover:not(:disabled) { background: #b91c1c; }
+
+.btn-danger-ghost {
+  background: transparent;
+  color: var(--fail);
+  padding: .5rem 1rem;
+  border: 1.5px solid var(--fail);
+  font-weight: 500;
+}
+.btn-danger-ghost:hover:not(:disabled) { background: #fee2e2; }
+
+/* ── Start screen ── */
+#start-screen {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 2.5rem 1rem 3rem;
+}
+
+.start-header { text-align: center; margin-bottom: 2rem; }
+.start-header h1 { font-size: 1.9rem; font-weight: 700; }
+.start-header p  { color: var(--muted); margin-top: .4rem; }
+
+.exam-list { display: flex; flex-direction: column; gap: .75rem; }
+
+.exam-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+.exam-card.highlighted { border-color: var(--primary); border-width: 2px; }
+
+.exam-meta { flex: 1; min-width: 0; }
+.exam-meta strong { display: block; font-size: 1rem; }
+.exam-meta .scenarios {
+  color: var(--muted);
+  font-size: .85rem;
+  margin-top: .2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.exam-meta .ts { color: var(--muted); font-size: .8rem; margin-top: .15rem; }
+
+.badge {
+  display: inline-block;
+  padding: .2rem .55rem;
+  border-radius: 99px;
+  font-size: .75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  flex-shrink: 0;
+}
+.badge-pass { background: #dcfce7; color: var(--pass); }
+.badge-fail { background: #fee2e2; color: var(--fail); }
+.badge-new  { background: #eff6ff; color: var(--primary); }
+
+.exam-card-actions { display: flex; gap: .5rem; flex-shrink: 0; }
+
+.import-hint { color: var(--muted); font-size: .85rem; margin-top: .5rem; }
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--primary);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+.btn-link:hover { color: var(--primary-h); }
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: var(--muted);
+}
+
+/* ── Exam screen ── */
+#exam-screen { display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
+
+/* Top bar */
+.exam-topbar {
+  background: #1e293b;
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: .65rem 1.25rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.exam-topbar h2 { font-size: .95rem; font-weight: 600; flex: 1; min-width: 0; }
+
+.timer {
+  font-variant-numeric: tabular-nums;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: .03em;
+  padding: .3rem .7rem;
+  background: rgba(255,255,255,.1);
+  border-radius: var(--radius);
+}
+.timer.warn   { background: #78350f; color: #fde68a; }
+.timer.urgent { background: #7f1d1d; color: #fecaca; animation: pulse 1s infinite; }
+
+@keyframes pulse { 0%,100% { opacity:1 } 50% { opacity:.6 } }
+
+.progress-text { font-size: .8rem; color: #94a3b8; white-space: nowrap; }
+
+/* Warning banner */
+.warn-banner {
+  background: #78350f;
+  color: #fde68a;
+  text-align: center;
+  padding: .4rem;
+  font-weight: 600;
+  font-size: .9rem;
+  flex-shrink: 0;
+}
+
+/* Body: sidebar + main */
+.exam-body {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.exam-sidebar {
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.case-brief h3 { font-size: .8rem; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin-bottom: .4rem; }
+.case-brief .brief-title { font-weight: 700; font-size: .95rem; margin-bottom: .4rem; }
+.case-brief .brief-text { font-size: .82rem; color: #374151; line-height: 1.55; }
+
+.q-nav h3 { font-size: .8rem; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin-bottom: .5rem; }
+.q-grid { display: flex; flex-wrap: wrap; gap: 4px; }
+
+.q-sq {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: var(--sq-none);
+  color: #374151;
+  font-size: .72rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform .1s;
+  border: 2px solid transparent;
+}
+.q-sq:hover { transform: scale(1.15); }
+.q-sq.answered  { background: var(--sq-ans);  color: #fff; }
+.q-sq.flagged   { background: var(--sq-flag); color: #fff; }
+.q-sq.current   { border-color: #1e293b; box-shadow: 0 0 0 2px #1e293b; }
+.q-sq.answered.flagged { background: linear-gradient(135deg, var(--sq-ans) 50%, var(--sq-flag) 50%); }
+
+.legend { display: flex; flex-wrap: wrap; gap: .4rem .75rem; font-size: .73rem; color: var(--muted); }
+.legend-item { display: flex; align-items: center; gap: .25rem; }
+.legend-dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+
+/* Main question area */
+.exam-main { overflow-y: auto; padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem; }
+
+.q-header {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+}
+.q-number { font-size: .85rem; color: var(--muted); font-weight: 600; }
+.btn-flag {
+  margin-left: auto;
+  font-size: .8rem;
+  padding: .3rem .75rem;
+  border-radius: 99px;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-weight: 500;
+}
+.btn-flag.flagged { border-color: var(--warn); color: var(--warn); background: #fffbeb; }
+
+.q-stem {
+  font-size: 1rem;
+  line-height: 1.65;
+  font-weight: 500;
+  padding: 1rem 1.25rem;
+  background: #f8fafc;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+.options { display: flex; flex-direction: column; gap: .5rem; }
+
+.option-row {
+  display: flex;
+  align-items: flex-start;
+  gap: .85rem;
+  padding: .8rem 1rem;
+  border-radius: var(--radius);
+  border: 1.5px solid var(--border);
+  cursor: pointer;
+  transition: border-color .15s, background .15s;
+  user-select: none;
+}
+.option-row:hover { background: #eff6ff; border-color: #93c5fd; }
+.option-row.selected { border-color: var(--primary); background: #eff6ff; }
+
+.option-letter {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .8rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: .05rem;
+  transition: border-color .15s, background .15s, color .15s;
+}
+.option-row.selected .option-letter {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+.option-text { font-size: .92rem; line-height: 1.5; }
+
+.q-actions {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  flex-wrap: wrap;
+}
+.q-actions .spacer { flex: 1; }
+
+.q-submit-row {
+  text-align: right;
+  margin-top: .25rem;
+}
+
+/* ── Result screen ── */
+#result-screen {
+  max-width: 740px;
+  margin: 0 auto;
+  padding: 2.5rem 1rem 3rem;
+}
+
+.result-header { text-align: center; margin-bottom: 2rem; }
+.result-header h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 1.25rem; }
+
+.score-block {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin-bottom: .75rem;
+}
+.score-number { font-size: 4rem; font-weight: 800; letter-spacing: -.02em; line-height: 1; }
+.score-denom  { font-size: 1.4rem; color: var(--muted); align-self: flex-end; padding-bottom: .4rem; }
+.verdict-badge {
+  font-size: 1.4rem;
+  font-weight: 800;
+  padding: .4rem 1.1rem;
+  border-radius: 99px;
+}
+.verdict-badge.pass { background: #dcfce7; color: var(--pass); }
+.verdict-badge.fail { background: #fee2e2; color: var(--fail); }
+
+.result-sub { color: var(--muted); font-size: .9rem; }
+
+.domain-breakdown { margin: 1.5rem 0; }
+.domain-breakdown h2 { font-size: 1rem; font-weight: 700; margin-bottom: 1rem; }
+
+.domain-row { margin-bottom: .9rem; }
+.domain-label { display: flex; justify-content: space-between; font-size: .85rem; margin-bottom: .25rem; }
+.domain-name  { font-weight: 500; }
+.domain-score { color: var(--muted); font-variant-numeric: tabular-nums; }
+.bar-track { background: var(--sq-none); border-radius: 99px; height: 10px; overflow: hidden; }
+.bar-fill  { height: 100%; border-radius: 99px; transition: width .6s ease; }
+.bar-strong { background: var(--pass); }
+.bar-mid    { background: var(--primary); }
+.bar-weak   { background: var(--fail); }
+
+.disclaimer {
+  font-size: .8rem;
+  color: var(--muted);
+  line-height: 1.55;
+  padding: 1rem;
+  border-radius: var(--radius);
+  background: #f9fafb;
+  border: 1px solid var(--border);
+  margin-top: 1.5rem;
+}
+
+.result-actions { display: flex; gap: .75rem; justify-content: center; margin-top: 1.5rem; flex-wrap: wrap; }
+
+/* ── Review screen ── */
+#review-screen {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.review-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+.review-header h1 { font-size: 1.4rem; font-weight: 700; flex: 1; }
+.review-summary { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+
+.review-section { margin-bottom: 2rem; }
+.review-section-header {
+  background: #1e293b;
+  color: #f8fafc;
+  border-radius: var(--radius) var(--radius) 0 0;
+  padding: .75rem 1.1rem;
+}
+.review-section-header h2 { font-size: .95rem; font-weight: 700; }
+.review-brief {
+  font-size: .82rem;
+  color: #94a3b8;
+  margin-top: .25rem;
+  line-height: 1.4;
+}
+
+.review-q {
+  border: 1px solid var(--border);
+  border-top: none;
+  padding: 1rem 1.1rem;
+  background: var(--surface);
+}
+.review-q:last-child { border-radius: 0 0 var(--radius) var(--radius); }
+
+.review-q-header {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  margin-bottom: .6rem;
+  font-size: .82rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+.review-verdict {
+  margin-left: auto;
+  font-weight: 700;
+  font-size: .85rem;
+}
+.review-verdict.correct { color: var(--pass); }
+.review-verdict.wrong   { color: var(--fail); }
+.review-verdict.skipped { color: var(--muted); }
+
+.review-stem {
+  font-size: .92rem;
+  line-height: 1.6;
+  margin-bottom: .75rem;
+  font-weight: 500;
+}
+
+.review-option {
+  display: flex;
+  align-items: flex-start;
+  gap: .75rem;
+  padding: .55rem .8rem;
+  border-radius: 6px;
+  border: 1.5px solid transparent;
+  margin-bottom: .35rem;
+  font-size: .88rem;
+  line-height: 1.45;
+}
+.review-option.correct-ans {
+  border-color: var(--pass);
+  background: #f0fdf4;
+}
+.review-option.wrong-ans {
+  border-color: var(--fail);
+  background: #fef2f2;
+}
+.review-option .opt-letter {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: .05rem;
+}
+.review-option.correct-ans .opt-letter { background: var(--pass); border-color: var(--pass); color: #fff; }
+.review-option.wrong-ans   .opt-letter { background: var(--fail); border-color: var(--fail); color: #fff; }
+
+.opt-tag {
+  margin-left: auto;
+  font-size: .73rem;
+  font-weight: 700;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding-left: .5rem;
+}
+.correct-ans .opt-tag { color: var(--pass); }
+.wrong-ans   .opt-tag { color: var(--fail); }
+
+/* ── Utility ── */
+.hidden { display: none !important; }
+.spinner { text-align: center; padding: 3rem; color: var(--muted); font-size: .95rem; }
+
+/* Confirm overlay */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.overlay-box {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 20px 60px rgba(0,0,0,.2);
+}
+.overlay-box h3 { font-size: 1.1rem; margin-bottom: .5rem; }
+.overlay-box p  { color: var(--muted); font-size: .9rem; margin-bottom: 1.25rem; line-height: 1.5; }
+.overlay-actions { display: flex; gap: .75rem; justify-content: flex-end; }
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════ START SCREEN ═══════════════════════════ -->
+<div id="start-screen" class="hidden">
+  <div class="start-header">
+    <h1>CCAF Mock Exam</h1>
+    <p>Claude Certified Architect – Foundations &nbsp;|&nbsp; 60 questions &nbsp;|&nbsp; 120 minutes</p>
+  </div>
+  <div id="exam-list" class="exam-list">
+    <div class="spinner">Loading exams…</div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════ EXAM SCREEN ════════════════════════════ -->
+<div id="exam-screen" class="hidden">
+  <div class="exam-topbar">
+    <h2 id="exam-title">CCAF Mock Exam</h2>
+    <span id="progress-text" class="progress-text"></span>
+    <span id="timer" class="timer">2:00:00</span>
+  </div>
+  <div id="warn-banner" class="warn-banner hidden">⚠ 5 minutes remaining — finish up and submit</div>
+  <div class="exam-body">
+    <!-- Sidebar -->
+    <div class="exam-sidebar">
+      <div class="case-brief" id="case-brief">
+        <h3>Case Study</h3>
+        <div class="brief-title" id="brief-title">—</div>
+        <div class="brief-text"  id="brief-text">—</div>
+      </div>
+      <div class="q-nav">
+        <h3>Questions</h3>
+        <div class="q-grid" id="q-grid"></div>
+        <div class="legend" style="margin-top:.6rem">
+          <span class="legend-item"><span class="legend-dot" style="background:var(--sq-none);border:1px solid #9ca3af"></span> Unanswered</span>
+          <span class="legend-item"><span class="legend-dot" style="background:var(--sq-ans)"></span> Answered</span>
+          <span class="legend-item"><span class="legend-dot" style="background:var(--sq-flag)"></span> Flagged</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main -->
+    <div class="exam-main" id="exam-main">
+      <div class="spinner">Loading…</div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════ RESULT SCREEN ══════════════════════════ -->
+<div id="result-screen" class="hidden">
+  <div class="result-header">
+    <h1>CCAF Mock Exam — Result</h1>
+    <div class="score-block">
+      <span class="score-number" id="res-score">—</span>
+      <span class="score-denom">/ 1000</span>
+      <span class="verdict-badge" id="res-verdict">—</span>
+    </div>
+    <p class="result-sub" id="res-correct"></p>
+  </div>
+
+  <div class="card domain-breakdown" style="padding:1.25rem">
+    <h2>Per-Domain Breakdown</h2>
+    <div id="domain-rows"></div>
+  </div>
+
+  <p class="disclaimer">
+    <strong>Estimated score only.</strong> This score is calculated as
+    <code>100 + 15 × correct</code> — a linear mapping over the real 100–1000 band. It is
+    <em>not</em> Anthropic's proprietary equating curve. Treat 720+ here as a readiness signal,
+    not a guarantee. Pass line: 720 (≥ 42 / 60 correct).
+  </p>
+
+  <div class="result-actions">
+    <button class="btn-ghost" onclick="location.reload()">Back to Exam Library</button>
+  </div>
+</div>
+
+<!-- ═══════════════════════════ REVIEW SCREEN ══════════════════════════ -->
+<div id="review-screen" class="hidden">
+  <div class="review-header">
+    <h1>Exam Review</h1>
+    <div class="review-summary" id="review-summary"></div>
+    <button class="btn-ghost" onclick="location.reload()">← Library</button>
+  </div>
+  <div id="review-body"></div>
+</div>
+
+<!-- Confirm submit overlay -->
+<div id="submit-overlay" class="overlay hidden">
+  <div class="overlay-box">
+    <h3 id="overlay-title">Submit exam?</h3>
+    <p id="overlay-body"></p>
+    <div class="overlay-actions">
+      <button class="btn-ghost" onclick="App.closeOverlay()">Cancel</button>
+      <button class="btn-danger" id="overlay-confirm-btn">Submit</button>
+    </div>
+  </div>
+</div>
+
+<script>
+'use strict';
+
+// ── Config ──────────────────────────────────────────────────────────────────
+const PORT = 8765;
+const API  = `http://localhost:${PORT}`;
+// NOTE: keep in sync with DOMAIN_NAMES in web/server.py
+const DOMAIN_NAMES = {
+  D1: 'Agentic Architecture & Orchestration',
+  D2: 'Tool Design & MCP Integration',
+  D3: 'Claude Code Configuration & Workflows',
+  D4: 'Prompt Engineering & Structured Output',
+  D5: 'Context Management & Reliability',
+};
+const TIMER_TOTAL = 120 * 60; // seconds
+const WARN_AT     = 5 * 60;   // seconds remaining for warning
+
+// ── State ────────────────────────────────────────────────────────────────────
+let examCache = [];  // mirror of the last /exams response for rename/delete lookups
+
+const examState = {
+  exam:        null,   // loaded exam JSON
+  allQ:        [],     // flattened question list [{...q, sectionIdx}]
+  answers:     {},     // {n: 'A'|'B'|'C'|'D'}
+  flags:       new Set(),
+  curIdx:      0,      // index into allQ
+  secondsLeft: TIMER_TOTAL,
+  timerTick:   null,
+  warnShown:   false,
+  submitted:   false,
+};
+
+// ── DOM helper ────────────────────────────────────────────────────────────────
+const byId = id => document.getElementById(id);
+
+// ── Screens ──────────────────────────────────────────────────────────────────
+function showScreen(name) {
+  ['start-screen','exam-screen','result-screen','review-screen'].forEach(id => {
+    byId(id).classList.toggle('hidden', id !== name + '-screen');
+  });
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+function fmtTime(s) {
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2,'0')}:${String(sec).padStart(2,'0')}`;
+  return `${m}:${String(sec).padStart(2,'0')}`;
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso + 'Z'); // server writes naive UTC; append Z for correct parsing
+  return d.toLocaleString(undefined, {dateStyle:'medium', timeStyle:'short'});
+}
+
+function decodeKey(b64) {
+  try { return atob(b64); } catch { return '?'; }
+}
+
+function esc(s) {
+  return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+// ── Start Screen ─────────────────────────────────────────────────────────────
+async function initStart() {
+  showScreen('start');
+  const urlExam = new URLSearchParams(location.search).get('exam') || '';
+
+  let exams = [];
+  try {
+    const r = await fetch(`${API}/exams`);
+    exams = await r.json();
+  } catch {
+    byId('exam-list').innerHTML = `<div class="spinner">Could not connect to the exam server at localhost:${PORT}.<br>Make sure you launched the server via <code>/ccaf:mock-exam --web</code>.</div>`;
+    return;
+  }
+
+  if (!exams.length) {
+    byId('exam-list').innerHTML = `<div class="empty-state">No saved exams yet.<br>Run <code>/ccaf:mock-exam --web</code> in Claude Code to generate one.</div>`;
+    return;
+  }
+
+  examCache = exams;
+  byId('exam-list').innerHTML = exams.map(e => {
+    const isNew = e.id === urlExam;
+    const badge = e.completed
+      ? `<span class="badge ${e.verdict === 'PASS' ? 'badge-pass' : 'badge-fail'}">${esc(e.verdict) || ''} ${e.scaled != null ? esc(String(e.scaled)) : ''}</span>`
+      : (isNew ? `<span class="badge badge-new">New</span>` : '');
+    const actions = e.completed
+      ? `<button class="btn-ghost"        onclick="App.reviewExam('${e.id}')">Review</button>
+         <button class="btn-primary"      onclick="App.retakeExam('${e.id}')">Retake</button>`
+      : `<button class="btn-primary"      onclick="App.startExam('${e.id}')">${isNew ? 'Start' : 'Take'}</button>`;
+    return `
+      <div class="card exam-card ${isNew ? 'highlighted' : ''}">
+        <div class="exam-meta">
+          <strong>${esc(e.id)}</strong>
+          <div class="scenarios">${(e.scenarios || []).join(' · ')}</div>
+          <div class="ts">${fmtDate(e.generated_at)}</div>
+        </div>
+        ${badge}
+        <div class="exam-card-actions">${actions}</div>
+      </div>`;
+  }).join('');
+}
+
+// ── Exam Loading ──────────────────────────────────────────────────────────────
+async function startExam(id) {
+  showScreen('exam');
+  byId('exam-main').innerHTML = '<div class="spinner">Loading exam…</div>';
+
+  let exam;
+  try {
+    const r = await fetch(`${API}/exam/${id}`);
+    if (!r.ok) throw new Error(r.status);
+    exam = await r.json();
+  } catch (e) {
+    byId('exam-main').innerHTML = `<div class="spinner">Failed to load exam: ${e.message}</div>`;
+    return;
+  }
+
+  examState.exam = exam;
+  examState.allQ = exam.sections.flatMap((sec, si) =>
+    sec.questions.map(q => ({ ...q, sectionIdx: si }))
+  );
+  examState.answers    = {};
+  examState.flags      = new Set();
+  examState.curIdx     = 0;
+  examState.secondsLeft = TIMER_TOTAL;
+  examState.warnShown  = false;
+  examState.submitted  = false;
+
+  byId('exam-title').textContent = 'CCAF Mock Exam — ' + exam.id;
+  renderQGrid();
+  renderQuestion();
+  startTimer();
+}
+
+// ── Timer ─────────────────────────────────────────────────────────────────────
+function startTimer() {
+  if (examState.timerTick) clearInterval(examState.timerTick);
+  updateTimerEl();
+  examState.timerTick = setInterval(() => {
+    examState.secondsLeft--;
+    updateTimerEl();
+    if (examState.secondsLeft <= WARN_AT && !examState.warnShown) {
+      examState.warnShown = true;
+      byId('warn-banner').classList.remove('hidden');
+    }
+    if (examState.secondsLeft <= 0) {
+      clearInterval(examState.timerTick);
+      autoSubmit();
+    }
+  }, 1000);
+}
+
+function updateTimerEl() {
+  const el = byId('timer');
+  el.textContent = fmtTime(Math.max(0, examState.secondsLeft));
+  el.className = 'timer';
+  if (examState.secondsLeft <= 60)         el.classList.add('urgent');
+  else if (examState.secondsLeft <= WARN_AT) el.classList.add('warn');
+}
+
+function stopTimer() {
+  if (examState.timerTick) { clearInterval(examState.timerTick); examState.timerTick = null; }
+}
+
+// ── Question render ───────────────────────────────────────────────────────────
+function updateSidebar(q) {
+  const sec = examState.exam.sections[q.sectionIdx];
+  byId('brief-title').textContent = sec.title || sec.scenario;
+  byId('brief-text').textContent  = sec.brief  || '';
+}
+
+function updateProgress() {
+  const answered = Object.keys(examState.answers).length;
+  byId('progress-text').textContent = `${answered} / ${examState.exam.total} answered`;
+}
+
+function renderQGrid() {
+  const grid = byId('q-grid');
+  grid.innerHTML = examState.allQ.map((q, idx) => {
+    const ans = examState.answers[q.n] != null;
+    const flg = examState.flags.has(q.n);
+    const cur = idx === examState.curIdx;
+    const cls = [ans && 'answered', flg && 'flagged', cur && 'current'].filter(Boolean).join(' ');
+    return `<div class="q-sq ${cls}" onclick="App.navTo(${idx})" title="Q${q.n}">${q.n}</div>`;
+  }).join('');
+}
+
+function renderQuestion() {
+  const q = examState.allQ[examState.curIdx];
+  if (!q) return;
+
+  updateSidebar(q);
+  updateProgress();
+
+  const flagged  = examState.flags.has(q.n);
+  const isLast   = examState.curIdx === examState.allQ.length - 1;
+
+  byId('exam-main').innerHTML = `
+    <div class="q-header">
+      <span class="q-number">Question ${q.n} of ${examState.exam.total} &nbsp;·&nbsp; ${q.domain_name || q.domain}</span>
+      <button class="btn-flag ${flagged ? 'flagged' : ''}" onclick="App.toggleFlag(${q.n})">
+        ${flagged ? '⚑ Flagged' : '⚐ Flag for review'}
+      </button>
+    </div>
+
+    <div class="q-stem">${esc(q.stem)}</div>
+
+    <div class="options">
+      ${['A','B','C','D'].map(ltr => {
+        const text = q.options[ltr] || '';
+        const sel  = examState.answers[q.n] === ltr;
+        return `
+          <div class="option-row ${sel ? 'selected' : ''}" onclick="App.selectOption(${q.n}, '${ltr}')">
+            <div class="option-letter">${ltr}</div>
+            <div class="option-text">${esc(text)}</div>
+          </div>`;
+      }).join('')}
+    </div>
+
+    <div class="q-actions">
+      <button class="btn-ghost" onclick="App.navTo(${examState.curIdx - 1})" ${examState.curIdx === 0 ? 'disabled' : ''}>← Previous</button>
+      <span class="spacer"></span>
+      <button class="btn-primary" onclick="App.navTo(${examState.curIdx + 1})" ${isLast ? 'disabled' : ''}>Next →</button>
+    </div>
+
+    <div class="q-submit-row">
+      <button class="btn-danger" style="font-size:.8rem;padding:.3rem .8rem"
+              onclick="App.confirmSubmit()">Submit Exam</button>
+    </div>
+  `;
+
+  renderQGrid();
+}
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+function navTo(idx) {
+  if (idx < 0 || idx >= examState.allQ.length) return;
+  examState.curIdx = idx;
+  renderQuestion();
+  byId('exam-main').scrollTop = 0;
+}
+
+// ── Answer / Flag ─────────────────────────────────────────────────────────────
+function selectOption(qn, letter) {
+  examState.answers[qn] = letter;
+  renderQuestion();
+}
+
+function toggleFlag(qn) {
+  if (examState.flags.has(qn)) examState.flags.delete(qn);
+  else examState.flags.add(qn);
+  renderQuestion();
+}
+
+// ── Submit flow ───────────────────────────────────────────────────────────────
+function confirmSubmit() {
+  if (examState.submitted) return;
+  const unanswered = examState.exam.total - Object.keys(examState.answers).length;
+  const flagged    = examState.flags.size;
+  let body = '';
+  if (unanswered > 0) body += `${unanswered} question(s) unanswered (will score as incorrect). `;
+  if (flagged > 0)    body += `${flagged} question(s) still flagged. `;
+  body += 'Are you sure you want to submit?';
+
+  byId('overlay-title').textContent = 'Submit exam?';
+  byId('overlay-body').textContent  = body;
+  byId('overlay-confirm-btn').onclick = () => doSubmit();
+  byId('submit-overlay').classList.remove('hidden');
+}
+
+function closeOverlay() {
+  byId('submit-overlay').classList.add('hidden');
+}
+
+function autoSubmit() {
+  if (examState.submitted) return;
+  byId('warn-banner').textContent = '⏱ Time is up — submitting your exam…';
+  byId('warn-banner').classList.remove('hidden');
+  doSubmit();
+}
+
+async function doSubmit() {
+  if (examState.submitted) return;
+  examState.submitted = true;
+  closeOverlay();
+  stopTimer();
+
+  const result = computeScore();
+  showScreen('result');
+  renderResult(result);
+
+  // POST to server (best-effort — exam is already scored in the browser)
+  try {
+    await fetch(`${API}/submit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(result),
+    });
+  } catch { /* server may already be gone if this is a retry */ }
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────────────
+function computeScore() {
+  const per_domain = {};
+  let correct = 0;
+
+  for (const sec of examState.exam.sections) {
+    for (const q of sec.questions) {
+      const d = q.domain;
+      if (!per_domain[d]) per_domain[d] = { correct: 0, total: 0 };
+      per_domain[d].total++;
+      const key = decodeKey(q.key);
+      if (examState.answers[q.n] === key) {
+        correct++;
+        per_domain[d].correct++;
+      }
+    }
+  }
+
+  const total   = examState.exam.total;
+  const scaled  = 100 + 15 * correct;
+  const verdict = scaled >= 720 ? 'PASS' : 'FAIL';
+
+  return {
+    exam_id: examState.exam.id,
+    answers: examState.answers,
+    correct,
+    total,
+    scaled,
+    verdict,
+    per_domain,
+  };
+}
+
+// ── Result Screen ─────────────────────────────────────────────────────────────
+function renderResult(r) {
+  byId('res-score').textContent   = r.scaled;
+  byId('res-correct').textContent = `${r.correct} of ${r.total} correct  ·  Pass line: 720`;
+
+  const vEl = byId('res-verdict');
+  vEl.textContent = r.verdict;
+  vEl.className   = `verdict-badge ${r.verdict === 'PASS' ? 'pass' : 'fail'}`;
+
+  const domainOrder = ['D1','D2','D3','D4','D5'];
+  byId('domain-rows').innerHTML = domainOrder
+    .filter(d => r.per_domain[d])
+    .map(d => {
+      const { correct, total } = r.per_domain[d];
+      const pct      = total ? Math.round(correct / total * 100) : 0;
+      const name     = DOMAIN_NAMES[d] || d;
+      const weakTag  = pct < 60 ? ' <span style="color:var(--fail);font-size:.75rem;font-weight:600">▲ Study this</span>' : '';
+      const barClass = pct >= 70 ? 'bar-strong' : pct >= 50 ? 'bar-mid' : 'bar-weak';
+      return `
+        <div class="domain-row">
+          <div class="domain-label">
+            <span class="domain-name">${d} — ${name}${weakTag}</span>
+            <span class="domain-score">${correct}/${total} (${pct}%)</span>
+          </div>
+          <div class="bar-track">
+            <div class="bar-fill ${barClass}" style="width:${pct}%"></div>
+          </div>
+        </div>`;
+    }).join('');
+
+  renderRecommendation(r);
+}
+
+function renderRecommendation(r) {
+  const domainOrder = ['D1','D2','D3','D4','D5'];
+  const rec = document.createElement('p');
+  if (r.verdict === 'FAIL') {
+    const weakest = domainOrder
+      .filter(d => r.per_domain[d])
+      .sort((a, b) => {
+        const pa = r.per_domain[a].correct / r.per_domain[a].total;
+        const pb = r.per_domain[b].correct / r.per_domain[b].total;
+        return pa - pb;
+      })[0];
+    rec.style.cssText = 'margin-top:.75rem;font-size:.9rem;color:var(--text)';
+    rec.innerHTML = `Your weakest area is <strong>${weakest} — ${DOMAIN_NAMES[weakest]}</strong>. Run <code>/ccaf:prepare ${weakest}</code> in Claude Code for targeted practice, then retake the mock.`;
+  } else {
+    rec.style.cssText = 'margin-top:.75rem;font-size:.9rem;color:var(--pass);font-weight:600';
+    rec.textContent = '✓ You\'re on track to pass — good luck on the real exam!';
+  }
+  byId('domain-rows').appendChild(rec);
+}
+
+// ── Retake ────────────────────────────────────────────────────────────────────
+// Reuses the same exam JSON and stored keys — no Claude generation required.
+// startExam resets all state (answers, flags, timer) before loading.
+function retakeExam(id) {
+  startExam(id);
+}
+
+// ── Review ────────────────────────────────────────────────────────────────────
+async function reviewExam(id) {
+  showScreen('review');
+  byId('review-body').innerHTML = '<div class="spinner">Loading…</div>';
+
+  let exam, result;
+  try {
+    const [er, rr] = await Promise.all([
+      fetch(`${API}/exam/${id}`),
+      fetch(`${API}/result/${id}`),
+    ]);
+    if (!er.ok) throw new Error(`Exam fetch failed: ${er.status}`);
+    if (!rr.ok) throw new Error(`Result fetch failed: ${rr.status}`);
+    exam   = await er.json();
+    result = await rr.json();
+  } catch (e) {
+    byId('review-body').innerHTML = `<div class="spinner">Failed to load: ${e.message}</div>`;
+    return;
+  }
+
+  renderReview(exam, result);
+}
+
+function renderReview(exam, result) {
+  const userAnswers = result.answers || {};  // {"1": "B", ...}
+
+  const vClass = result.verdict === 'PASS' ? 'badge-pass' : 'badge-fail';
+  byId('review-summary').innerHTML = `
+    <span class="badge ${vClass}">${result.verdict} ${result.scaled}</span>
+    <span style="color:var(--muted);font-size:.85rem">${result.correct}/${result.total} correct</span>`;
+
+  byId('review-body').innerHTML = exam.sections.map(sec => {
+    const qCards = sec.questions.map(q => {
+      const correctKey = decodeKey(q.key);
+      const userChoice = userAnswers[String(q.n)];
+      const gotItRight = userChoice === correctKey;
+      const skipped    = userChoice == null || userChoice === '';
+
+      const verdictLabel = skipped
+        ? '<span class="review-verdict skipped">— Skipped</span>'
+        : gotItRight
+          ? '<span class="review-verdict correct">✓ Correct</span>'
+          : '<span class="review-verdict wrong">✗ Wrong</span>';
+
+      const optionRows = ['A','B','C','D'].map(ltr => {
+        const text        = q.options[ltr] || '';
+        const isCorrect   = ltr === correctKey;
+        const isUserWrong = ltr === userChoice && !gotItRight;
+        const isUserRight = ltr === userChoice && gotItRight;
+
+        let cls = '', tag = '';
+        if (isUserRight) {
+          cls = 'correct-ans';
+          tag = '✓ Correct — Your answer';
+        } else if (isCorrect) {
+          cls = 'correct-ans';
+          tag = '✓ Correct answer';
+        } else if (isUserWrong) {
+          cls = 'wrong-ans';
+          tag = '✗ Your answer';
+        }
+
+        return `
+          <div class="review-option ${cls}">
+            <div class="opt-letter">${ltr}</div>
+            <div>${esc(text)}</div>
+            ${tag ? `<div class="opt-tag">${tag}</div>` : ''}
+          </div>`;
+      }).join('');
+
+      return `
+        <div class="review-q">
+          <div class="review-q-header">
+            <span>Q${q.n}</span>
+            <span>${q.domain} — ${q.domain_name || q.domain}</span>
+            ${verdictLabel}
+          </div>
+          <div class="review-stem">${esc(q.stem)}</div>
+          ${optionRows}
+        </div>`;
+    }).join('');
+
+    return `
+      <div class="review-section">
+        <div class="review-section-header">
+          <h2>${esc(sec.title || sec.scenario)}</h2>
+          <div class="review-brief">${esc(sec.brief)}</div>
+        </div>
+        ${qCards}
+      </div>`;
+  }).join('');
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+window.App = {
+  startExam,
+  retakeExam,
+  reviewExam,
+  navTo,
+  selectOption,
+  toggleFlag,
+  confirmSubmit,
+  closeOverlay,
+};
+
+// ── Boot ──────────────────────────────────────────────────────────────────────
+initStart();
+</script>
+</body>
+</html>

--- a/ccaf/web/app.html
+++ b/ccaf/web/app.html
@@ -628,14 +628,6 @@ button:disabled { opacity: .45; cursor: default; }
 // ── Config ──────────────────────────────────────────────────────────────────
 const PORT = 8765;
 const API  = `http://localhost:${PORT}`;
-// NOTE: keep in sync with DOMAIN_NAMES in web/server.py
-const DOMAIN_NAMES = {
-  D1: 'Agentic Architecture & Orchestration',
-  D2: 'Tool Design & MCP Integration',
-  D3: 'Claude Code Configuration & Workflows',
-  D4: 'Prompt Engineering & Structured Output',
-  D5: 'Context Management & Reliability',
-};
 const TIMER_TOTAL = 120 * 60; // seconds
 const WARN_AT     = 5 * 60;   // seconds remaining for warning
 
@@ -656,6 +648,13 @@ const examState = {
 
 // ── DOM helper ────────────────────────────────────────────────────────────────
 const byId = id => document.getElementById(id);
+
+// Full domain name from the loaded exam's payload (the server is the single source);
+// falls back to the bare code (e.g. "D1") if the exam predates the domain_names field.
+function domainName(code) {
+  const names = examState.exam && examState.exam.domain_names;
+  return (names && names[code]) || code;
+}
 
 // ── Screens ──────────────────────────────────────────────────────────────────
 function showScreen(name) {
@@ -982,7 +981,7 @@ function renderResult(r) {
     .map(d => {
       const { correct, total } = r.per_domain[d];
       const pct      = total ? Math.round(correct / total * 100) : 0;
-      const name     = DOMAIN_NAMES[d] || d;
+      const name     = domainName(d);
       const weakTag  = pct < 60 ? ' <span style="color:var(--fail);font-size:.75rem;font-weight:600">▲ Study this</span>' : '';
       const barClass = pct >= 70 ? 'bar-strong' : pct >= 50 ? 'bar-mid' : 'bar-weak';
       return `
@@ -1012,7 +1011,7 @@ function renderRecommendation(r) {
         return pa - pb;
       })[0];
     rec.style.cssText = 'margin-top:.75rem;font-size:.9rem;color:var(--text)';
-    rec.innerHTML = `Your weakest area is <strong>${weakest} — ${DOMAIN_NAMES[weakest]}</strong>. Run <code>/ccaf:prepare ${weakest}</code> in Claude Code for targeted practice, then retake the mock.`;
+    rec.innerHTML = `Your weakest area is <strong>${weakest} — ${domainName(weakest)}</strong>. Run <code>/ccaf:prepare ${weakest}</code> in Claude Code for targeted practice, then retake the mock.`;
   } else {
     rec.style.cssText = 'margin-top:.75rem;font-size:.9rem;color:var(--pass);font-weight:600';
     rec.textContent = '✓ You\'re on track to pass — good luck on the real exam!';
@@ -1030,6 +1029,26 @@ function exportExam(id) {
   document.body.removeChild(a);
 }
 
+// ── API helper ────────────────────────────────────────────────────────────────
+// Calls the local server. On failure, alerts "<action> failed: <reason>" and
+// returns null; on success returns the parsed JSON body ({} if none).
+async function apiCall(action, path, options) {
+  let r;
+  try {
+    r = await fetch(`${API}${path}`, options);
+  } catch {
+    alert(`${action} failed: could not reach the server.`);
+    return null;
+  }
+  let body = {};
+  try { body = await r.json(); } catch { /* response may carry no body */ }
+  if (!r.ok) {
+    alert(`${action} failed: ${body.error || `HTTP ${r.status}`}`);
+    return null;
+  }
+  return body;
+}
+
 // ── Rename exam ───────────────────────────────────────────────────────────────
 async function renameExam(id) {
   const cached = examCache.find(e => e.id === id);
@@ -1038,15 +1057,11 @@ async function renameExam(id) {
   if (newName === null || newName.trim() === currentName.trim()) return;
   const trimmed = newName.trim();
   if (!trimmed) return;
-  try {
-    const r = await fetch(`${API}/exam/${id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: trimmed }),
-    });
-    if (r.ok) initStart();
-    else { const j = await r.json(); alert(`Rename failed: ${j.error}`); }
-  } catch { alert('Rename failed: could not reach the server.'); }
+  if (await apiCall('Rename', `/exam/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: trimmed }),
+  })) initStart();
 }
 
 // ── Delete exam ───────────────────────────────────────────────────────────────
@@ -1054,19 +1069,12 @@ async function deleteExam(id) {
   const cached = examCache.find(e => e.id === id);
   const displayName = cached ? (cached.name || id) : id;
   if (!window.confirm(`Delete "${displayName}"?\n\nThis cannot be undone.`)) return;
-  try {
-    const r = await fetch(`${API}/exam/${id}`, { method: 'DELETE' });
-    if (r.ok) initStart();
-    else { const j = await r.json(); alert(`Delete failed: ${j.error}`); }
-  } catch { alert('Delete failed: could not reach the server.'); }
+  if (await apiCall('Delete', `/exam/${id}`, { method: 'DELETE' })) initStart();
 }
 
 // ── Open exams folder ─────────────────────────────────────────────────────────
 async function openFolder() {
-  try {
-    const r = await fetch(`${API}/reveal`);
-    if (!r.ok) { const j = await r.json(); alert(`Could not open folder: ${j.error}`); }
-  } catch { alert('Could not open folder: server not reachable.'); }
+  await apiCall('Open folder', '/reveal');
 }
 
 // ── Import ────────────────────────────────────────────────────────────────────
@@ -1092,21 +1100,11 @@ async function handleImportFile(event) {
     return;
   }
 
-  try {
-    const r = await fetch(`${API}/import`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(exam),
-    });
-    const result = await r.json();
-    if (!r.ok) {
-      alert(`Import failed: ${result.error}`);
-      return;
-    }
-    initStart(); // refresh exam list with the newly imported exam
-  } catch {
-    alert('Import failed: could not reach the server.');
-  }
+  if (await apiCall('Import', '/import', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(exam),
+  })) initStart(); // refresh exam list with the newly imported exam
 }
 
 // ── Retake ────────────────────────────────────────────────────────────────────

--- a/ccaf/web/app.html
+++ b/ccaf/web/app.html
@@ -529,7 +529,9 @@ button:disabled { opacity: .45; cursor: default; }
   <div class="start-header">
     <h1>CCAF Mock Exam</h1>
     <p>Claude Certified Architect – Foundations &nbsp;|&nbsp; 60 questions &nbsp;|&nbsp; 120 minutes</p>
+    <p class="import-hint">Colleague shared an exam? <button class="btn-link" onclick="App.openImport()">Import JSON file</button> &nbsp;·&nbsp; <button class="btn-link" onclick="App.openFolder()">Open exams folder</button></p>
   </div>
+  <input type="file" id="import-input" accept=".json" style="display:none" onchange="App.handleImportFile(event)">
   <div id="exam-list" class="exam-list">
     <div class="spinner">Loading exams…</div>
   </div>
@@ -712,12 +714,18 @@ async function initStart() {
       : (isNew ? `<span class="badge badge-new">New</span>` : '');
     const actions = e.completed
       ? `<button class="btn-ghost"        onclick="App.reviewExam('${e.id}')">Review</button>
-         <button class="btn-primary"      onclick="App.retakeExam('${e.id}')">Retake</button>`
-      : `<button class="btn-primary"      onclick="App.startExam('${e.id}')">${isNew ? 'Start' : 'Take'}</button>`;
+         <button class="btn-primary"      onclick="App.retakeExam('${e.id}')">Retake</button>
+         <button class="btn-ghost"        onclick="App.exportExam('${e.id}')">Export</button>
+         <button class="btn-ghost"        onclick="App.renameExam('${e.id}')">Rename</button>
+         <button class="btn-danger-ghost" onclick="App.deleteExam('${e.id}')">Delete</button>`
+      : `<button class="btn-primary"      onclick="App.startExam('${e.id}')">${isNew ? 'Start' : 'Take'}</button>
+         <button class="btn-ghost"        onclick="App.exportExam('${e.id}')">Export</button>
+         <button class="btn-ghost"        onclick="App.renameExam('${e.id}')">Rename</button>
+         <button class="btn-danger-ghost" onclick="App.deleteExam('${e.id}')">Delete</button>`;
     return `
       <div class="card exam-card ${isNew ? 'highlighted' : ''}">
         <div class="exam-meta">
-          <strong>${esc(e.id)}</strong>
+          <strong>${esc(e.name || e.id)}</strong>
           <div class="scenarios">${(e.scenarios || []).join(' · ')}</div>
           <div class="ts">${fmtDate(e.generated_at)}</div>
         </div>
@@ -1012,6 +1020,95 @@ function renderRecommendation(r) {
   byId('domain-rows').appendChild(rec);
 }
 
+// ── Export ────────────────────────────────────────────────────────────────────
+function exportExam(id) {
+  const a = document.createElement('a');
+  a.href = `${API}/exam/${id}`;
+  a.download = `${id}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+// ── Rename exam ───────────────────────────────────────────────────────────────
+async function renameExam(id) {
+  const cached = examCache.find(e => e.id === id);
+  const currentName = cached ? (cached.name || id) : id;
+  const newName = window.prompt('Rename exam:', currentName);
+  if (newName === null || newName.trim() === currentName.trim()) return;
+  const trimmed = newName.trim();
+  if (!trimmed) return;
+  try {
+    const r = await fetch(`${API}/exam/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: trimmed }),
+    });
+    if (r.ok) initStart();
+    else { const j = await r.json(); alert(`Rename failed: ${j.error}`); }
+  } catch { alert('Rename failed: could not reach the server.'); }
+}
+
+// ── Delete exam ───────────────────────────────────────────────────────────────
+async function deleteExam(id) {
+  const cached = examCache.find(e => e.id === id);
+  const displayName = cached ? (cached.name || id) : id;
+  if (!window.confirm(`Delete "${displayName}"?\n\nThis cannot be undone.`)) return;
+  try {
+    const r = await fetch(`${API}/exam/${id}`, { method: 'DELETE' });
+    if (r.ok) initStart();
+    else { const j = await r.json(); alert(`Delete failed: ${j.error}`); }
+  } catch { alert('Delete failed: could not reach the server.'); }
+}
+
+// ── Open exams folder ─────────────────────────────────────────────────────────
+async function openFolder() {
+  try {
+    const r = await fetch(`${API}/reveal`);
+    if (!r.ok) { const j = await r.json(); alert(`Could not open folder: ${j.error}`); }
+  } catch { alert('Could not open folder: server not reachable.'); }
+}
+
+// ── Import ────────────────────────────────────────────────────────────────────
+function openImport() {
+  byId('import-input').click();
+}
+
+async function handleImportFile(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+  event.target.value = ''; // reset so the same file can be re-selected later
+
+  let exam;
+  try {
+    exam = JSON.parse(await file.text());
+  } catch (e) {
+    alert(`Could not parse JSON: ${e.message}`);
+    return;
+  }
+
+  if (!exam.id || !Array.isArray(exam.sections) || !exam.total) {
+    alert('Invalid exam file — missing required fields (id, sections, total).');
+    return;
+  }
+
+  try {
+    const r = await fetch(`${API}/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(exam),
+    });
+    const result = await r.json();
+    if (!r.ok) {
+      alert(`Import failed: ${result.error}`);
+      return;
+    }
+    initStart(); // refresh exam list with the newly imported exam
+  } catch {
+    alert('Import failed: could not reach the server.');
+  }
+}
+
 // ── Retake ────────────────────────────────────────────────────────────────────
 // Reuses the same exam JSON and stored keys — no Claude generation required.
 // startExam resets all state (answers, flags, timer) before loading.
@@ -1117,6 +1214,12 @@ window.App = {
   startExam,
   retakeExam,
   reviewExam,
+  exportExam,
+  renameExam,
+  deleteExam,
+  openFolder,
+  openImport,
+  handleImportFile,
   navTo,
   selectOption,
   toggleFlag,

--- a/ccaf/web/app.html
+++ b/ccaf/web/app.html
@@ -1228,6 +1228,10 @@ window.App = {
 };
 
 // ── Boot ──────────────────────────────────────────────────────────────────────
+// Keep the server alive while the tab is open; it auto-shuts after IDLE_TIMEOUT
+// seconds of silence (handles crashes). The beacon fires immediately on close.
+setInterval(() => fetch(`${API}/heartbeat`).catch(() => {}), 10_000);
+window.addEventListener('beforeunload', () => navigator.sendBeacon(`${API}/shutdown`));
 initStart();
 </script>
 </body>

--- a/ccaf/web/server.py
+++ b/ccaf/web/server.py
@@ -200,6 +200,7 @@ def cmd_export(args):
 
     exam_data = {
         "id": args.exam_id,
+        "name": args.name or args.exam_id,
         "generated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
         "scenarios": scenarios_list,
         "domain_distribution": domain_dist,
@@ -263,12 +264,31 @@ class ExamHandler(BaseHTTPRequestHandler):
         elif path.startswith("/result/"):
             self._serve_result(path[8:])
 
+        elif path == "/reveal":
+            self._reveal_folder()
+
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_DELETE(self):
+        path = self.path.split("?")[0].rstrip("/") or "/"
+        if path.startswith("/exam/"):
+            self._handle_delete(path[6:])
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_PATCH(self):
+        path = self.path.split("?")[0].rstrip("/") or "/"
+        if path.startswith("/exam/"):
+            self._handle_patch_exam(path[6:])
         else:
             self._json({"error": "not found"}, 404)
 
     def do_POST(self):
         if self.path == "/submit":
             self._handle_submit()
+        elif self.path == "/import":
+            self._handle_import()
         else:
             self._json({"error": "not found"}, 404)
 
@@ -295,6 +315,7 @@ class ExamHandler(BaseHTTPRequestHandler):
                     pass
             exams.append({
                 "id": exam_id,
+                "name": data.get("name", exam_id),
                 "generated_at": data.get("generated_at", ""),
                 "scenarios": data.get("scenarios", []),
                 "total": data.get("total", 60),
@@ -356,6 +377,114 @@ class ExamHandler(BaseHTTPRequestHandler):
         self._json({"ok": True})
         threading.Thread(target=self.server.shutdown, daemon=True).start()
 
+    def _handle_delete(self, exam_id):
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid exam id"}, 400)
+            return
+        exam_path = os.path.join(self.server.exam_dir, f"{exam_id}.json")
+        if not os.path.exists(exam_path):
+            self._json({"error": "not found"}, 404)
+            return
+        os.remove(exam_path)
+        result_path = os.path.join(self.server.exam_dir, f"{exam_id}-result.json")
+        if os.path.exists(result_path):
+            os.remove(result_path)
+        self._json({"ok": True})
+
+    def _handle_patch_exam(self, exam_id):
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid exam id"}, 400)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            updates = json.loads(body)
+        except (ValueError, json.JSONDecodeError) as e:
+            self._json({"error": str(e)}, 400)
+            return
+        new_name = updates.get("name", "")
+        if not isinstance(new_name, str) or not new_name.strip():
+            self._json({"error": "name must be a non-empty string"}, 400)
+            return
+        exam_path = os.path.join(self.server.exam_dir, f"{exam_id}.json")
+        if not os.path.exists(exam_path):
+            self._json({"error": "not found"}, 404)
+            return
+        try:
+            with open(exam_path, encoding="utf-8") as fh:
+                exam = json.load(fh)
+            exam["name"] = new_name.strip()
+            with open(exam_path, "w", encoding="utf-8") as fh:
+                json.dump(exam, fh, indent=2, ensure_ascii=False)
+        except (OSError, json.JSONDecodeError) as e:
+            self._json({"error": str(e)}, 500)
+            return
+        self._json({"ok": True})
+
+    def _reveal_folder(self):
+        import platform
+        import subprocess
+        exam_dir = self.server.exam_dir
+        os.makedirs(exam_dir, exist_ok=True)
+        system = platform.system()
+        try:
+            if system == "Darwin":
+                subprocess.Popen(["open", exam_dir])
+            elif system == "Linux":
+                subprocess.Popen(["xdg-open", exam_dir])
+            else:
+                self._json({"error": "unsupported platform"}, 400)
+                return
+            self._json({"ok": True})
+        except OSError as e:
+            self._json({"error": str(e)}, 500)
+
+    def _handle_import(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            exam = json.loads(body)
+        except (ValueError, json.JSONDecodeError) as e:
+            self._json({"error": str(e)}, 400)
+            return
+
+        exam_id = exam.get("id", "")
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid or missing exam id"}, 400)
+            return
+
+        if not isinstance(exam.get("sections"), list) or not exam.get("total"):
+            self._json({"error": "invalid exam: missing sections or total"}, 400)
+            return
+
+        # Validate every question the browser will score. A missing key/options/stem
+        # imports silently and then mis-scores (decodeKey yields '?', every answer
+        # marked wrong) with no error — so reject it at the boundary instead.
+        for section in exam["sections"]:
+            for q in section.get("questions", []):
+                missing = [f for f in ("key", "options", "stem") if not q.get(f)]
+                if missing:
+                    self._json({
+                        "error": f"invalid exam: question {q.get('n', '?')} "
+                                 f"missing {', '.join(missing)}"
+                    }, 400)
+                    return
+
+        out_path = os.path.join(self.server.exam_dir, f"{exam_id}.json")
+        if os.path.exists(out_path):
+            self._json({"error": "exam already exists", "id": exam_id}, 409)
+            return
+
+        try:
+            os.makedirs(self.server.exam_dir, exist_ok=True)
+            with open(out_path, "w", encoding="utf-8") as fh:
+                json.dump(exam, fh, indent=2, ensure_ascii=False)
+        except OSError as e:
+            self._json({"error": str(e)}, 500)
+            return
+
+        self._json({"ok": True, "id": exam_id})
+
 
 def cmd_serve(args):
     server = HTTPServer(("127.0.0.1", args.port), ExamHandler)
@@ -383,6 +512,7 @@ def main():
     exp.add_argument("--exam-id",   required=True, help="Exam identifier (e.g. ccaf-20260619-143022)")
     exp.add_argument("--exam-src",  required=True, help="Path prefix for exam files (without .md suffix)")
     exp.add_argument("--exam-dir",  required=True, help="Directory to write the JSON into")
+    exp.add_argument("--name",      default="",    help="Human-readable display name for this exam")
 
     srv = sub.add_parser("serve", help="Run the HTTP server")
     srv.add_argument("--port",        type=int, default=8765, help="TCP port (default 8765)")

--- a/ccaf/web/server.py
+++ b/ccaf/web/server.py
@@ -142,6 +142,8 @@ def parse_answers_file(path):
 # Export mode
 # ---------------------------------------------------------------------------
 
+IDLE_TIMEOUT = 60  # seconds of browser silence before auto-shutdown
+
 # NOTE: keep in sync with DOMAIN_NAMES in web/app.html
 DOMAIN_NAMES = {
     "D1": "Agentic Architecture & Orchestration",
@@ -233,6 +235,20 @@ class ExamHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _cancel_idle_timer(self):
+        timer = getattr(self.server, '_idle_timer', None)
+        if timer:
+            timer.cancel()
+            self.server._idle_timer = None
+
+    def _reset_idle_timer(self):
+        self._cancel_idle_timer()
+        self.server._idle_timer = threading.Timer(
+            IDLE_TIMEOUT,
+            lambda: threading.Thread(target=self.server.shutdown, daemon=True).start(),
+        )
+        self.server._idle_timer.start()
+
     def do_GET(self):
         path = self.path.split("?")[0].rstrip("/") or "/"
 
@@ -264,6 +280,13 @@ class ExamHandler(BaseHTTPRequestHandler):
         elif path.startswith("/result/"):
             self._serve_result(path[8:])
 
+        elif path == "/heartbeat":
+            self._reset_idle_timer()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok")
+
         elif path == "/reveal":
             self._reveal_folder()
 
@@ -287,6 +310,10 @@ class ExamHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         if self.path == "/submit":
             self._handle_submit()
+        elif self.path == "/shutdown":
+            self._cancel_idle_timer()
+            self._json({"ok": True})
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
         elif self.path == "/import":
             self._handle_import()
         else:
@@ -375,6 +402,7 @@ class ExamHandler(BaseHTTPRequestHandler):
             return
 
         self._json({"ok": True})
+        self._cancel_idle_timer()
         threading.Thread(target=self.server.shutdown, daemon=True).start()
 
     def _handle_delete(self, exam_id):
@@ -490,6 +518,14 @@ def cmd_serve(args):
     server = HTTPServer(("127.0.0.1", args.port), ExamHandler)
     server.exam_dir = os.path.expanduser(args.exam_dir)
     server.plugin_root = args.plugin_root
+    server._idle_timer = None
+    # Arm immediately so a browser that closes before the first heartbeat
+    # (which fires after 10 s) still triggers shutdown.
+    server._idle_timer = threading.Timer(
+        IDLE_TIMEOUT,
+        lambda: threading.Thread(target=server.shutdown, daemon=True).start(),
+    )
+    server._idle_timer.start()
     print(f"CCAF exam server listening on http://localhost:{args.port}")
     try:
         server.serve_forever()

--- a/ccaf/web/server.py
+++ b/ccaf/web/server.py
@@ -29,7 +29,7 @@ import os
 import re
 import sys
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
@@ -144,7 +144,6 @@ def parse_answers_file(path):
 
 IDLE_TIMEOUT = 60  # seconds of browser silence before auto-shutdown
 
-# NOTE: keep in sync with DOMAIN_NAMES in web/app.html
 DOMAIN_NAMES = {
     "D1": "Agentic Architecture & Orchestration",
     "D2": "Tool Design & MCP Integration",
@@ -203,7 +202,7 @@ def cmd_export(args):
     exam_data = {
         "id": args.exam_id,
         "name": args.name or args.exam_id,
-        "generated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"),
         "scenarios": scenarios_list,
         "domain_distribution": domain_dist,
         "domain_names": DOMAIN_NAMES,
@@ -234,6 +233,14 @@ class ExamHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _valid_id(self, exam_id):
+        """Reject ids that are unsafe as a filename (path traversal, etc.).
+        On failure, sends a 400 and returns False; returns True when safe."""
+        if re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            return True
+        self._json({"error": "invalid exam id"}, 400)
+        return False
 
     def _cancel_idle_timer(self):
         timer = getattr(self.server, '_idle_timer', None)
@@ -368,14 +375,12 @@ class ExamHandler(BaseHTTPRequestHandler):
             self._json({"error": str(e)}, 500)
 
     def _serve_exam(self, exam_id):
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid exam id"}, 400)
+        if not self._valid_id(exam_id):
             return
         self._serve_json_file(os.path.join(self.server.exam_dir, f"{exam_id}.json"))
 
     def _serve_result(self, exam_id):
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid exam id"}, 400)
+        if not self._valid_id(exam_id):
             return
         self._serve_json_file(os.path.join(self.server.exam_dir, f"{exam_id}-result.json"))
 
@@ -389,8 +394,7 @@ class ExamHandler(BaseHTTPRequestHandler):
             return
 
         exam_id = result.get("exam_id", "")
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid exam_id"}, 400)
+        if not self._valid_id(exam_id):
             return
 
         result_path = os.path.join(self.server.exam_dir, f"{exam_id}-result.json")
@@ -406,8 +410,7 @@ class ExamHandler(BaseHTTPRequestHandler):
         threading.Thread(target=self.server.shutdown, daemon=True).start()
 
     def _handle_delete(self, exam_id):
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid exam id"}, 400)
+        if not self._valid_id(exam_id):
             return
         exam_path = os.path.join(self.server.exam_dir, f"{exam_id}.json")
         if not os.path.exists(exam_path):
@@ -420,8 +423,7 @@ class ExamHandler(BaseHTTPRequestHandler):
         self._json({"ok": True})
 
     def _handle_patch_exam(self, exam_id):
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid exam id"}, 400)
+        if not self._valid_id(exam_id):
             return
         try:
             length = int(self.headers.get("Content-Length", 0))
@@ -477,8 +479,7 @@ class ExamHandler(BaseHTTPRequestHandler):
             return
 
         exam_id = exam.get("id", "")
-        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
-            self._json({"error": "invalid or missing exam id"}, 400)
+        if not self._valid_id(exam_id):
             return
 
         if not isinstance(exam.get("sections"), list) or not exam.get("total"):

--- a/ccaf/web/server.py
+++ b/ccaf/web/server.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""
+CCAF Exam Web Server — stdlib only, no external dependencies.
+
+Two modes (select with first positional arg):
+
+  export   --exam-id ID --exam-src PATH --exam-dir DIR
+           Parse ~/.claude/ccaf-exam.local.md + .answers.md, write
+           DIR/ID.json with Base64-obfuscated answer keys. Then exit.
+
+  serve    --port PORT --exam-dir DIR --plugin-root PATH
+           Serve the HTML app and exam API on PORT until a /submit
+           POST is received, then shut down cleanly.
+
+Routes (serve mode):
+  GET  /             → web/app.html
+  GET  /ping         → 200 "pong"  (reuse detection)
+  GET  /exams        → JSON list of exams in exam-dir (metadata only)
+  GET  /exam/<id>    → full exam JSON (questions + obfuscated keys)
+  GET  /result/<id>  → result JSON for a completed exam
+  POST /submit       → save result JSON, schedule shutdown
+"""
+
+import argparse
+import base64
+import glob
+import json
+import os
+import re
+import sys
+import threading
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+# ---------------------------------------------------------------------------
+# Exam file parser
+# ---------------------------------------------------------------------------
+
+def parse_questions_file(path):
+    """
+    Returns (total, scenarios_list, cases_dict, questions_list).
+
+    cases_dict: {slug: {title, brief}}
+    questions_list: [{n, domain, scenario, stem, options:{A,B,C,D}}]
+    """
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    # -- Strip frontmatter --
+    total = 60
+    scenarios_str = ""
+    i = 0
+    if lines and lines[0] == "---":
+        i = 1
+        while i < len(lines) and lines[i] != "---":
+            if lines[i].startswith("total: "):
+                total = int(lines[i][7:].strip())
+            elif lines[i].startswith("scenarios: "):
+                scenarios_str = lines[i][11:].strip()
+            i += 1
+        i += 1  # skip closing ---
+
+    cases = {}           # slug → {title, brief}
+    questions = []
+    current_case = None  # slug of the current [[CASE:]] block
+    in_case_header = False
+    current_q = None     # dict being built
+
+    for line in lines[i:]:
+        # Case block header. Slug grammar [a-z0-9-]+ — keep in sync with the
+        # awk validator in scripts/ccaf-exam.sh (check_composition_questions).
+        m = re.match(r"^\[\[CASE:([a-z0-9-]+)\]\]$", line)
+        if m:
+            if current_q is not None:
+                questions.append(current_q)
+                current_q = None
+            current_case = m.group(1)
+            cases[current_case] = {"title": "", "brief": ""}
+            in_case_header = True
+            continue
+
+        # Question block header
+        m = re.match(r"^\[\[Q(\d+)\]\]$", line)
+        if m:
+            if current_q is not None:
+                questions.append(current_q)
+            current_q = {
+                "n": int(m.group(1)),
+                "domain": "",
+                "scenario": current_case or "",
+                "stem": "",
+                "options": {},
+            }
+            in_case_header = False
+            continue
+
+        # Case-block header fields (title/brief before first Q)
+        if in_case_header and current_case:
+            if line.startswith("title: "):
+                cases[current_case]["title"] = line[7:]
+            elif line.startswith("brief: "):
+                cases[current_case]["brief"] = line[7:]
+            continue
+
+        # Question fields
+        if current_q is not None:
+            if line.startswith("domain: "):
+                current_q["domain"] = line[8:]
+            elif line.startswith("stem: "):
+                current_q["stem"] = line[6:]
+            elif len(line) >= 3 and line[0] in "ABCD" and line[1:3] == ") ":
+                current_q["options"][line[0]] = line[3:]
+
+    if current_q is not None:
+        questions.append(current_q)
+
+    scenarios_list = [s for s in scenarios_str.split(",") if s]
+    return total, scenarios_list, cases, questions
+
+
+def parse_answers_file(path):
+    """Returns {qnum(int): key_letter(str)} from the answers file."""
+    keys = {}
+    fm_dashes = 0
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line == "---":
+                fm_dashes += 1
+                continue
+            if fm_dashes < 2:
+                continue
+            # Data line: "N DOMAIN KEY USER"
+            parts = line.split()
+            if len(parts) == 4 and parts[0].isdigit() and re.match(r"^[A-D]$", parts[2]):
+                keys[int(parts[0])] = parts[2]
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# Export mode
+# ---------------------------------------------------------------------------
+
+# NOTE: keep in sync with DOMAIN_NAMES in web/app.html
+DOMAIN_NAMES = {
+    "D1": "Agentic Architecture & Orchestration",
+    "D2": "Tool Design & MCP Integration",
+    "D3": "Claude Code Configuration & Workflows",
+    "D4": "Prompt Engineering & Structured Output",
+    "D5": "Context Management & Reliability",
+}
+
+
+def cmd_export(args):
+    q_path = args.exam_src + ".md"
+    a_path = args.exam_src + ".answers.md"
+
+    if not os.path.exists(q_path):
+        sys.exit(f"export: questions file not found: {q_path}")
+    if not os.path.exists(a_path):
+        sys.exit(f"export: answers file not found: {a_path}")
+
+    total, scenarios_list, cases, questions = parse_questions_file(q_path)
+    keys = parse_answers_file(a_path)
+
+    # Domain distribution
+    domain_dist = {}
+    for q in questions:
+        domain_dist[q["domain"]] = domain_dist.get(q["domain"], 0) + 1
+
+    # Build sections in scenario order
+    sections = []
+    for slug in scenarios_list:
+        case = cases.get(slug, {"title": slug, "brief": ""})
+        section_qs = []
+        for q in questions:
+            if q["scenario"] != slug:
+                continue
+            key_letter = keys.get(q["n"])
+            if not key_letter:
+                sys.exit(
+                    f"export: no answer key for question {q['n']} — check the answers file"
+                )
+            obfuscated = base64.b64encode(key_letter.encode()).decode()
+            section_qs.append({
+                "n": q["n"],
+                "domain": q["domain"],
+                "domain_name": DOMAIN_NAMES.get(q["domain"], q["domain"]),
+                "stem": q["stem"],
+                "options": q["options"],
+                "key": obfuscated,
+            })
+        sections.append({
+            "scenario": slug,
+            "title": case["title"],
+            "brief": case["brief"],
+            "questions": section_qs,
+        })
+
+    exam_data = {
+        "id": args.exam_id,
+        "generated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"),
+        "scenarios": scenarios_list,
+        "domain_distribution": domain_dist,
+        "domain_names": DOMAIN_NAMES,
+        "total": total,
+        "sections": sections,
+    }
+
+    os.makedirs(args.exam_dir, exist_ok=True)
+    out_path = os.path.join(args.exam_dir, f"{args.exam_id}.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(exam_data, fh, indent=2, ensure_ascii=False)
+
+    print(f"Exported: {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+
+class ExamHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # silence access log
+        pass
+
+    def _json(self, data, status=200):
+        body = json.dumps(data, ensure_ascii=False).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?")[0].rstrip("/") or "/"
+
+        if path == "/ping":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"pong")
+
+        elif path == "/":
+            app_path = os.path.join(self.server.plugin_root, "web", "app.html")
+            try:
+                with open(app_path, "rb") as fh:
+                    content = fh.read()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(content)))
+                self.end_headers()
+                self.wfile.write(content)
+            except FileNotFoundError:
+                self._json({"error": "app.html not found"}, 404)
+
+        elif path == "/exams":
+            self._list_exams()
+
+        elif path.startswith("/exam/"):
+            self._serve_exam(path[6:])
+
+        elif path.startswith("/result/"):
+            self._serve_result(path[8:])
+
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def do_POST(self):
+        if self.path == "/submit":
+            self._handle_submit()
+        else:
+            self._json({"error": "not found"}, 404)
+
+    def _list_exams(self):
+        exam_dir = self.server.exam_dir
+        exams = []
+        pattern = os.path.join(exam_dir, "ccaf-*.json")
+        for fpath in sorted(glob.glob(pattern), reverse=True):
+            if fpath.endswith("-result.json"):
+                continue
+            try:
+                with open(fpath, encoding="utf-8") as fh:
+                    data = json.load(fh)
+            except (json.JSONDecodeError, OSError):
+                continue
+            exam_id = data.get("id", "")
+            result_path = os.path.join(exam_dir, f"{exam_id}-result.json")
+            result = None
+            if os.path.exists(result_path):
+                try:
+                    with open(result_path, encoding="utf-8") as fh:
+                        result = json.load(fh)
+                except (json.JSONDecodeError, OSError):
+                    pass
+            exams.append({
+                "id": exam_id,
+                "generated_at": data.get("generated_at", ""),
+                "scenarios": data.get("scenarios", []),
+                "total": data.get("total", 60),
+                "completed": result is not None,
+                "verdict": result.get("verdict") if result else None,
+                "scaled": result.get("scaled") if result else None,
+            })
+        self._json(exams)
+
+    def _serve_json_file(self, fpath):
+        if not os.path.exists(fpath):
+            self._json({"error": "not found"}, 404)
+            return
+        try:
+            with open(fpath, "rb") as fh:
+                content = fh.read()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        except OSError as e:
+            self._json({"error": str(e)}, 500)
+
+    def _serve_exam(self, exam_id):
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid exam id"}, 400)
+            return
+        self._serve_json_file(os.path.join(self.server.exam_dir, f"{exam_id}.json"))
+
+    def _serve_result(self, exam_id):
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid exam id"}, 400)
+            return
+        self._serve_json_file(os.path.join(self.server.exam_dir, f"{exam_id}-result.json"))
+
+    def _handle_submit(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            result = json.loads(body)
+        except (ValueError, json.JSONDecodeError) as e:
+            self._json({"error": str(e)}, 400)
+            return
+
+        exam_id = result.get("exam_id", "")
+        if not re.match(r"^[a-zA-Z0-9_-]+$", exam_id):
+            self._json({"error": "invalid exam_id"}, 400)
+            return
+
+        result_path = os.path.join(self.server.exam_dir, f"{exam_id}-result.json")
+        try:
+            with open(result_path, "w", encoding="utf-8") as fh:
+                json.dump(result, fh, indent=2, ensure_ascii=False)
+        except OSError as e:
+            self._json({"error": str(e)}, 500)
+            return
+
+        self._json({"ok": True})
+        threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+
+def cmd_serve(args):
+    server = HTTPServer(("127.0.0.1", args.port), ExamHandler)
+    server.exam_dir = os.path.expanduser(args.exam_dir)
+    server.plugin_root = args.plugin_root
+    print(f"CCAF exam server listening on http://localhost:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    exp = sub.add_parser("export", help="Convert exam files to JSON")
+    exp.add_argument("--exam-id",   required=True, help="Exam identifier (e.g. ccaf-20260619-143022)")
+    exp.add_argument("--exam-src",  required=True, help="Path prefix for exam files (without .md suffix)")
+    exp.add_argument("--exam-dir",  required=True, help="Directory to write the JSON into")
+
+    srv = sub.add_parser("serve", help="Run the HTTP server")
+    srv.add_argument("--port",        type=int, default=8765, help="TCP port (default 8765)")
+    srv.add_argument("--exam-dir",    required=True, help="Directory containing exam JSON files")
+    srv.add_argument("--plugin-root", required=True, help="Plugin root directory (for app.html)")
+
+    args = parser.parse_args()
+    args.exam_dir = os.path.expanduser(args.exam_dir)
+
+    if args.mode == "export":
+        cmd_export(args)
+    else:
+        cmd_serve(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds

A browser-based exam mode triggered by `/ccaf:mock-exam --web`. The terminal flow is unchanged — `--web` is strictly opt-in.

Running `/ccaf:mock-exam --web` assembles the 60-question exam as usual, exports it to a local JSON file, starts a lightweight Python stdlib server (zero external deps), and opens the browser. You take the exam in the browser; the server shuts itself down when you submit or close the tab.

## Why

The terminal exam has two gaps the real CCAF exam doesn't: a visible save-wait between question batches, and no enforced countdown. Web mode removes both — exam state lives in the browser during the attempt, with a real 120-minute timer. It also adds free navigation, per-question flagging, a per-domain result chart, and a persistent, shareable exam library.

## The 4 commits

| Commit | What it does |
|--------|--------------|
| **browser-based exam mode via `/ccaf:mock-exam --web`** | Stdlib HTTP server (export + serve), self-contained single-file browser app (start / exam / result / review screens, client-side scoring `100 + 15×correct`, pass 720), launcher with server-reuse detection, command/skill wiring, parser + core-route tests. |
| **share & manage the exam library** | Exams persist in `~/Documents/CCAF Exams` (Finder-visible) and share as JSON. Start screen gains import, rename, delete, export, open-folder. Exports carry a `<user> - <date>` name; import validates scorable questions. Exams from the legacy `~/.claude/ccaf-exams` are auto-migrated to the new location on launch. |
| **auto-shutdown the web server when the browser closes** | `beforeunload` beacon (`POST /shutdown`) stops the server on tab close; a 60 s idle timer (armed at startup, reset by a 10 s `GET /heartbeat`) covers crashes, force-quits, and sleep. |
| **refactor: dedupe id validation, API calls & domain names** | Behavior-preserving clean-up from review — `_valid_id()` replaces the id check duplicated across 6 server handlers; `apiCall()` replaces the fetch→alert block hand-rolled 4× in the browser; `DOMAIN_NAMES` is single-sourced from the exam payload; `datetime.utcnow()` → `datetime.now(timezone.utc)`. |

The first three are one shippable capability each; the fourth is a behavior-preserving clean-up. All carry their own tests, and the suite stays green.

## Routes (serve mode)

`GET /`, `/ping`, `/exams`, `/exam/<id>`, `/result/<id>`, `/heartbeat`, `/reveal` · `POST /submit`, `/shutdown`, `/import` · `PATCH /exam/<id>` · `DELETE /exam/<id>`. Binds to `127.0.0.1:8765` only.

## Tests

```
python3 scripts/tests/server.test.py   # 33 tests, all passing
bash scripts/tests/ccaf-exam.test.sh   # 75 passing (1 pre-existing failure, unrelated to this PR)
```

## Out of scope / known limits

- The pre-existing `ccaf-exam.test.sh` failure (`question under mismatched case block`) predates this branch.
- Honor system (as in terminal mode) — answer keys are Base64-obfuscated, not encrypted.
- Fixed port 8765, localhost only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
